### PR TITLE
Add Flatpak integration target to indoc instructions

### DIFF
--- a/resources/Documentation/indoc-instructions.txt
+++ b/resources/Documentation/indoc-instructions.txt
@@ -525,6 +525,15 @@ gnome_app {
 	destination = ../inform7-ide/src/inform/
 }
 
+gnome_flatpak_app {
+    # HTML documentation installed to a different location for Flatpak builds
+    follow: in-application-instructions.txt
+    assume_Public_Library = yes
+    declare: GNOME
+    javascript_paste_method = David
+    destination = /app/tmp/inform
+}
+
 website {
 	# HTML for the pre-2019 I7 website
 	destination = Website/content/learn/man/


### PR DESCRIPTION
I found that when building a Flatpak package where the build of each
component is siloed from the others, I need to copy the integration files
into some shared location. Ideally this would be governed by a setting in
make-integration-settings.mk, but for now, add a separate target to indoc
which I will select with INDOCOPTS in my integration settings.