### PR TITLE
Build and run tests in Github Actions in Ubuntu

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -6,7 +6,14 @@ jobs:
   build-and-test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - run: .github/workflows/prepare.sh
       - run: bash scripts/first.sh
       - run: make check
+      # rebuild docs here
+      - name: Deploy docs to Github Pages
+        if: github.ref == 'refs/heads/master'
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          branch: gh-pages
+          folder: docs

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,0 +1,12 @@
+name: build-and-test
+
+on: [push, pull_request]
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: .github/workflows/prepare.sh
+      - run: bash scripts/first.sh
+      - run: make check

--- a/.github/workflows/prepare.sh
+++ b/.github/workflows/prepare.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+
+set -e
+
+ROOT=$PWD
+cd ..
+
+echo "Downloading Inweb"
+rm -rf inweb
+curl -Ls https://github.com/ganelson/inweb/archive/refs/heads/master.tar.gz | tar xz
+mv inweb-master inweb -f
+echo "Compiling Inweb"
+bash inweb/scripts/first.sh linux
+
+echo "Downloading Intest"
+rm -rf intest
+curl -Ls https://github.com/ganelson/intest/archive/refs/heads/master.tar.gz | tar xz
+mv intest-master intest -f
+echo "Compiling Intest"
+bash intest/scripts/first.sh
+
+cd $ROOT


### PR DESCRIPTION
A simple little script to build Inform 7 and run the tests in Github Actions. Only Linux for now, but other OSes probably won't be too hard to add.