### PR TITLE
Remove private repository disclaimers

### DIFF
--- a/scripts/inform.rmscript
+++ b/scripts/inform.rmscript
@@ -27,12 +27,6 @@ Writing and presenting Inform as a literate program was beyond the capabilities
 of existing LP software, so a new system for LP called Inweb
 has been spun off from Inform, and that has [its own repository](https://github.com/ganelson/inweb).
 
-__Disclaimer__. Because this is a private repository (until the next public
-release of Inform, when it will open), its GitHub pages server cannot be
-enabled yet. As a result links marked {WEBICON} lead only to raw HTML
-source, not to served web pages. They can in the mean time be browsed offline
-as static HTML files stored in "docs".
-
 ## Licence and copyright
 
 Except as noted, copyright in material in this repository (the "Package") is
@@ -140,8 +134,7 @@ trees and hedges."** (Michael Frayn)
 Inform is not a single program, but an assemblage of programs and resources.
 Some, including the inform7 compiler itself, are "literate programs", also
 called "webs". The notation {WEBICON} marks these, and links are provided to
-their human-readable forms. (This will be enabled when the repository
-becomes public: GitHub Pages does not work on private repositories.)
+their human-readable forms.
 
 ### Source for command-line tools
 


### PR DESCRIPTION
This removes a couple of disclaimers warning of functionality that does not yet work because this repository is private. As this repository has been made public, these disclaimers no longer serve a purpose.