### PR TITLE
patch to can't eat other people's food rule

### DIFF
--- a/inform7/extensions/standard_rules/Sections/Actions.w
+++ b/inform7/extensions/standard_rules/Sections/Actions.w
@@ -529,10 +529,14 @@ Check an actor eating (this is the can't eat clothing without removing it first 
 		if the actor is wearing the noun, stop the action.
 
 Check an actor eating (this is the can't eat other people's food rule):
-	if the noun is enclosed by a person (called the owner) who is not the actor:
-		if the actor is the player:
-			say "[The owner] [might not appreciate] that." (A);
-		stop the action.
+	if the actor does not hold the noun and the noun is enclosed by a person:
+		let the owner be the holder of the noun;
+		while the owner is not a person:
+			now the owner is the holder of the owner;
+		if the owner is not the actor:
+			if the actor is the player and the action is not silent:
+				say "[The owner] [might not appreciate] that." (A);
+			stop the action;
 
 Check an actor eating (this is the can't eat portable food without carrying it rule):
 	if the noun is portable and the actor is not carrying the noun:


### PR DESCRIPTION
This fixes a small bug in the Can't Eat Other People's Food rule that only occurs if a person encloses another person and the enclosed person tries to eat: they can't, because the food is enclosed by another person. This isn't a contrived scenario if Rideable Vehicles is included, though it could also come up if a person carries another person. This story demonstrates:

>Include Rideable Vehicles by Graham Nelson.
>
>Lab is a room.
>
>Horse is a rideable animal in the Lab.
>Hay is an edible thing.
>Horse carries hay.
>Jerky is an edible thing.
>Tom Thumb is a person.
>Player carries the jerky.
>Player carries Tom Thumb.
>sandwich is an edible thing.
>Tom Thumb carries sandwich.
>Brown paper bag is a container.
>Tom thumb carries brown paper bag.
>Apple is an edible thing.
>apple is in brown paper bag.
>Angus is a person in the lab.
>Yak is a rideable animal in the lab.
>Grass is an edible thing.
>Yak carries grass.
>Haggis is an edible thing.
>Angus carries haggis.
>Sporran is a wearable container.
>Angus wears sporran.
>Cullen Skink is an edible thing.
>Cullen skink is in the sporran.
>Stuart Little is a person.
>Angus carries Stuart Little.
>Cheese is an edible thing.
>Stuart little carries cheese.
Teeny pocket is a container.
>Stuart Little carries teeny pocket.
>Crumb is an edible thing.
>Crumb is in teeny pocket.
>
>persuasion rule for asking someone to try eating: persuasion succeeds.
>
>when play begins:
>    move player to horse;
>    move angus to yak.
>
>test me with "eat jerky / eat sandwich / eat hay / eat apple / tom, eat apple / angus, eat grass / angus, eat haggis / angus, eat cullen skink / angus, eat cheese / angus, eat crumb / stuart, eat crumb / stuart, eat cheese / tom, eat sandwich".

> 
The results are:


>test me
(Testing.)

>[1] eat jerky
Horse might not appreciate that.

>[2] eat sandwich
Tom Thumb might not appreciate that.

>[3] eat hay
Horse might not appreciate that.

>[4] eat apple
Tom Thumb might not appreciate that.

>[5] tom, eat apple
Tom Thumb is unable to do that.

>[6] angus, eat grass
Angus is unable to do that.

>[7] angus, eat haggis
Angus eats Haggis.

>[8] angus, eat cullen skink
(Angus first taking Cullen Skink)
Angus eats Cullen Skink.

>[9] angus, eat cheese
Angus is unable to do that.

>[10] angus, eat crumb
Angus is unable to do that.

>[11] stuart, eat crumb
Stuart Little is unable to do that.

>[12] stuart, eat cheese
Stuart Little is unable to do that.

>[13] tom, eat sandwich
Tom Thumb is unable to do that.


i.e., wrong for 1, 5, 11, 12, 13.

It's a small issue, but was encountered in the field: [Omitting an item from inventory](https://intfiction.org/t/omitting-an-item-from-inventory/54966).