### PR TITLE
single word doc patch for consistency in code samples for reduction

### DIFF
--- a/resources/Documentation/Writing with Inform.txt
+++ b/resources/Documentation/Writing with Inform.txt
@@ -15487,7 +15487,7 @@ which produces the list {"fifteen", "twenty-nine", "minus four"}.
 Lastly, reduction. In order to combine a whole list of values, we need a phrase to combine any two. Here are some samples:
 
 	To decide what number is the larger of (N - number) and (M - number)
-		(this is maximizing):
+		(this is maximization):
 		if N > M, decide on N;
 		decide on M.
 


### PR DESCRIPTION
The existing docs have "maximizing" in the phrase definition and "maximization" in the subsequent reduction. This standardizes on "maximization" (parallel to "concatenation" in the adjacent code examples).
