### PR TITLE
commiting style -> gtstyle fix

### DIFF
--- a/inform7/Internal/Extensions/Emily Short/Glulx Text Effects.i7x
+++ b/inform7/Internal/Extensions/Emily Short/Glulx Text Effects.i7x
@@ -102,39 +102,39 @@ Last before starting the virtual machine (this is the set text styles rule):
 		if there is a reversed entry:
 			set reversed for the style name entry to the reversed entry;
 
-To set the background color for (style - a glulx text style) to (N - a text):
-	(- GTE_SetStylehint( wintype_TextBuffer, {style}, stylehint_BackColor, GTE_ConvertColour( {N} ), (+ all-styles +) ); -).
+To set the background color for (gtstyle - a glulx text style) to (N - a text):
+	(- GTE_SetStylehint( wintype_TextBuffer, {gtstyle}, stylehint_BackColor, GTE_ConvertColour( {N} ), (+ all-styles +) ); -).
 
-To set the color for (style - a glulx text style) to (N - a text):
-	(- GTE_SetStylehint( wintype_TextBuffer, {style}, stylehint_TextColor, GTE_ConvertColour( {N} ), (+ all-styles +) ); -).
+To set the color for (gtstyle - a glulx text style) to (N - a text):
+	(- GTE_SetStylehint( wintype_TextBuffer, {gtstyle}, stylehint_TextColor, GTE_ConvertColour( {N} ), (+ all-styles +) ); -).
 
-To set the first line indentation for (style - a glulx text style) to (N - a number):
-	(- GTE_SetStylehint( wintype_TextBuffer, {style}, stylehint_ParaIndentation, {N}, (+ all-styles +) ); -).
+To set the first line indentation for (gtstyle - a glulx text style) to (N - a number):
+	(- GTE_SetStylehint( wintype_TextBuffer, {gtstyle}, stylehint_ParaIndentation, {N}, (+ all-styles +) ); -).
 
-To set fixed width for (style - a glulx text style) to (N - truth state):
-	(- GTE_SetStylehint( wintype_TextBuffer, {style}, stylehint_Proportional, ( {N} + 1 ) % 2, (+ all-styles +) ); -).
+To set fixed width for (gtstyle - a glulx text style) to (N - truth state):
+	(- GTE_SetStylehint( wintype_TextBuffer, {gtstyle}, stylehint_Proportional, ( {N} + 1 ) % 2, (+ all-styles +) ); -).
 
-To set the font weight for (style - a glulx text style) to (N - a font weight):
-	(- GTE_SetStylehint( wintype_TextBuffer, {style}, stylehint_Weight, {N} - 2, (+ all-styles +) ); -).
+To set the font weight for (gtstyle - a glulx text style) to (N - a font weight):
+	(- GTE_SetStylehint( wintype_TextBuffer, {gtstyle}, stylehint_Weight, {N} - 2, (+ all-styles +) ); -).
 
-To set the indentation for (style - a glulx text style) to (N - a number):
-	(- GTE_SetStylehint( wintype_TextBuffer, {style}, stylehint_Indentation, {N}, (+ all-styles +) ); -).
+To set the indentation for (gtstyle - a glulx text style) to (N - a number):
+	(- GTE_SetStylehint( wintype_TextBuffer, {gtstyle}, stylehint_Indentation, {N}, (+ all-styles +) ); -).
 
-To set italic for (style - a glulx text style) to (N - a truth state):
-	(- GTE_SetStylehint( wintype_TextBuffer, {style}, stylehint_Oblique, {N}, (+ all-styles +) ); -).
+To set italic for (gtstyle - a glulx text style) to (N - a truth state):
+	(- GTE_SetStylehint( wintype_TextBuffer, {gtstyle}, stylehint_Oblique, {N}, (+ all-styles +) ); -).
 
-To set the justification for (style - a glulx text style) to (N - a text justification):
-	(- GTE_SetStylehint( wintype_TextBuffer, {style}, stylehint_Justification, {N} - 1, (+ all-styles +) ); -).
+To set the justification for (gtstyle - a glulx text style) to (N - a text justification):
+	(- GTE_SetStylehint( wintype_TextBuffer, {gtstyle}, stylehint_Justification, {N} - 1, (+ all-styles +) ); -).
 
-To set the relative size for (style - a glulx text style) to (N - a number):
-	(- GTE_SetStylehint( wintype_TextBuffer, {style}, stylehint_Size, {N}, (+ all-styles +) ); -).
+To set the relative size for (gtstyle - a glulx text style) to (N - a number):
+	(- GTE_SetStylehint( wintype_TextBuffer, {gtstyle}, stylehint_Size, {N}, (+ all-styles +) ); -).
 
-To set reversed for (style - a glulx text style) to (N - a truth state):
-	(- GTE_SetStylehint( wintype_TextBuffer, {style}, stylehint_ReverseColor, {N}, (+ all-styles +) ); -).
+To set reversed for (gtstyle - a glulx text style) to (N - a truth state):
+	(- GTE_SetStylehint( wintype_TextBuffer, {gtstyle}, stylehint_ReverseColor, {N}, (+ all-styles +) ); -).
 
 Include (-
-[ GTE_SetStylehint wintype style hint N all_styles i;
-	if ( style == all_styles )
+[ GTE_SetStylehint wintype gtstyle hint N all_styles i;
+	if ( gtstyle == all_styles )
 	{
 		for ( i = 0: i < style_NUMSTYLES : i++ )
 		{
@@ -143,7 +143,7 @@ Include (-
 	}
 	else
 	{
-		glk_stylehint_set( wintype, style - 2, hint, N );
+		glk_stylehint_set( wintype, gtstyle - 2, hint, N );
 	}
 ];
 -).


### PR DESCRIPTION
I didn't try to test the affected functions, but it compiles now so I figure it can't be worse.

There was a make check error, but this is in master, too.

PM_PhraseInBracketsPlus failed to produce its namesake Problem message
Inform 7 v10.1.0 has started.
I've now read your source text, which is 18 words long.
I've also read Basic Inform by Graham Nelson, which is 7691 words long.
I've also read English Language by Graham Nelson, which is 2328 words long.
I've also read Standard Rules by Graham Nelson, which is 32168 words long.
  >--> An internal error has occurred: must emit schemas in INTER_VAL_VHMODE or
    INTER_VOID_VHMODE. The current sentence is 'Table of Locale Priorities
    notable-object (an object) locale description priority (a number) -- --
    with blank rows for each thing' (the Standard Rules, line 1119); the error
    was detected at line 276 of "inter/building-module/Chapter 2/Emitting Inter
    Schemas.w". This should never happen, and I am now halting in abject
    failure.