### PR TITLE
Typo fixes to core extension documentation

### DIFF
--- a/inform7/extensions/basic_inform/Sections/Phrase Definitions.w
+++ b/inform7/extensions/basic_inform/Sections/Phrase Definitions.w
@@ -347,7 +347,7 @@ To say only -- ending say_first_time (documented at phs_firsttime):
 @ Now some visual effects, which may or may not be rendered the way the user
 hopes: that's partly up to the virtual machine, unfortunately.
 
-See test case |BIP-SayOneOf|, though since |intest| runs on plain text only,
+See test case |BIP-SayFonts|, though since |intest| runs on plain text only,
 you may need to run this in the Inform application to be convinced.
 
 =
@@ -947,7 +947,7 @@ To seed the random-number generator with (N - number)
 	(documented at ph_seed):
 	(- VM_Seed_RNG({N}); -).
 
-@ A novel feature of Inform is that there is a default value of any kind: fpr
+@ A novel feature of Inform is that there is a default value of any kind: for
 example, it is 0 for a number, or the empty text for text. When Inform compiles
 a value of a given kind but isn't told what value to compile, it always
 chooses the default, which is why the following definition works.

--- a/inform7/extensions/basic_inform/Sections/Preamble.w
+++ b/inform7/extensions/basic_inform/Sections/Preamble.w
@@ -6,7 +6,7 @@ basic verbs and use options.
 
 @h Title.
 Every Inform 7 extension begins with a standard titling line and a
-rubric text, and this are no exception:
+rubric text, and this is no exception:
 
 =
 Version [[Version Number]] of Basic Inform by Graham Nelson begins here.

--- a/inform7/extensions/standard_rules/Sections/Phrase Definitions.w
+++ b/inform7/extensions/standard_rules/Sections/Phrase Definitions.w
@@ -73,7 +73,7 @@ To say text of (R - response)
 
 @h Using the list-writer.
 One of the most powerful features of Inform 6 was its list-writer, a lengthy
-piece of I6 code wbich now lives on as Inter code, in the |srules| template:
+piece of I6 code which now lives on as Inter code, in the |srules| template:
 see "ListWriter.i6t". The following phrases control it:
 
 =

--- a/inform7/extensions/standard_rules/Sections/Physical World Model.w
+++ b/inform7/extensions/standard_rules/Sections/Physical World Model.w
@@ -104,12 +104,12 @@ Definition: a scene is happening if I6 condition "scene_status-->(*1-1)==1"
 	says so (it is currently taking place).
 
 @h Kinds.
-Basic Imform provides the kind "object", but no specialisations of it. We
+Basic Inform provides the kind "object", but no specialisations of it. We
 will use objects to represent physical objects and locations, with the
 hierarchy given below. (The template code assumes these kinds will be
 declared in this order, so be careful rearranging them.)
 
-Note the two alterative plural definitions for the word "person", with
+Note the two alternative plural definitions for the word "person", with
 "people" being defined earlier to make it the default: "persons" is
 correct, but "people" is more idiomatically usual.
 


### PR DESCRIPTION
Fixes some typos in Basic Inform and Standard Rules documentation + the correct test case for the Saying Fonts section.