### PR TITLE
can't insert what's already inserted fix

### DIFF
--- a/inform7/extensions/standard_rules/Sections/Actions.w
+++ b/inform7/extensions/standard_rules/Sections/Actions.w
@@ -425,7 +425,7 @@ Check an actor inserting something into (this is the convert insert to drop wher
 Check an actor inserting something into (this is the can't insert what's already inserted rule):
 	if the noun is in the second noun:
 		if the actor is the player:
-			say "[The second noun] [are] already there." (A);
+			say "[The noun] [are] already there." (A);
 		stop the action.
 
 Check an actor inserting something into (this is the can't insert something into itself rule):


### PR DESCRIPTION
The can't insert what's already inserted rule says "[The second noun] [are] already there." instead of "[The noun] [are] already there.", hence:
```
The box is a container.
The snake is in the box.
The player carries the box.
test me with "put snake in box".
```
produces
```
>[1] put snake in box
The box is already there.
```
This changes second noun to noun.

inform/inform7/Tests/Test Cases/_Results_Ideal/Obedience-C.txt includes the undesirable results, so this currently fails Obedience-C. I was guessing you wouldn't want anyone else changing the desired test output, so I didn't change it myself.

```
>** put scarf into briefcase
[inserting the sparkly scarf into the briefcase]
The briefcase is already there.
[inserting the sparkly scarf into the briefcase - failed the can't insert what's already inserted rule]
```