### PR TITLE
consider parts in interpreting possessive adjectives

### DIFF
--- a/inform7/Internal/Inter/CommandParserKit/Sections/Parser.i6t
+++ b/inform7/Internal/Inter/CommandParserKit/Sections/Parser.i6t
@@ -2911,8 +2911,7 @@ Constant PREFER_HELD;
         if (indef_type & THAT_BIT ~= 0 && its_owner == actors_location) met++;
         if (indef_type & LIT_BIT ~= 0 && obj has light) met++;
         if (indef_type & UNLIT_BIT ~= 0 && obj hasnt light) met++;
-        if (indef_owner ~= 0 && its_owner == indef_owner) met++;
-
+        if (indef_owner ~= 0 && ((its_owner == indef_owner) || (CoreOf(obj) == indef_owner))) met++;
         if (met < threshold) {
             #Ifdef DEBUG;
             if (parser_trace >= 4)


### PR DESCRIPTION
currently, this code
```
Lab is a room.

eyes are a kind of thing.
eyes are a part of every person.
Alice is a woman.
Alice is in the lab.
Test me with "x her eyes / x eyes / her eyes".
```
yields
```
>[1] x her eyes
I only understood you as far as wanting to examine Alice.
 
>[2] x eyes
Which do you mean, your eyes or Alice's eyes?
 
>[3] her eyes
I only understood you as far as wanting to examine Alice.
```

with this change, that becomes

```
>[1] x her eyes
You see nothing special about Alice's eyes.

>[2] x eyes
Which do you mean, your eyes or Alice's eyes?

>[3] her eyes
You see nothing special about Alice's eyes.
```

I can see how you might be loath to mess with the Parser, but this is possibly sufficiently discrete and straightforward to be worth considering: in ScoreMatchL, just like a noun under consideration gets a single extra point if it's possessed by an owner with a possessive adjective corresponding to the one used near the noun, a noun that's a part of a person would get that point in that corresponding case.

If such a small advantage isn't deemed worth the risk, I understand.

This passes `make check` cleanly.