### PR TITLE
Parser hook for compliant characters

### DIFF
--- a/inform7/Internal/Inter/CommandParserKit/Sections/Parser.i6t
+++ b/inform7/Internal/Inter/CommandParserKit/Sections/Parser.i6t
@@ -1283,6 +1283,9 @@ communicates a snippet of words to another character, just as if the
 player had typed ANSWER ARFLE BARFLE GLOOP TO PERSON. For I7 purposes, the
 fake action |##NotUnderstood| does not exist.
 
+In order to assist people who do want to parse that type of mistyped command
+in extensions, wn is left pointing at the first word not parsed as a command.
+
 =
   .GiveError;
 
@@ -1292,6 +1295,7 @@ fake action |##NotUnderstood| does not exist.
             verb_wordnum = usual_grammar_after;
             jump AlmostReParse;
         }
+				m = wn; ! Save wn so extension authors can parse command errors if they want to
         wn = 1;
         while ((wn <= num_words) && (NextWord() ~= comma_word)) ;
         parser_results-->ACTION_PRES = ##Answer;
@@ -1300,6 +1304,7 @@ fake action |##NotUnderstood| does not exist.
         parser_results-->INP2_PRES = 1; special_number1 = special_word;
         actor = player;
         consult_from = wn; consult_words = num_words-consult_from+1;
+				wn = m; ! Restore wn so extension authors can parse command errors if they want to
         rtrue;
     }
 

--- a/inform7/Internal/Inter/CommandParserKit/Sections/Parser.i6t
+++ b/inform7/Internal/Inter/CommandParserKit/Sections/Parser.i6t
@@ -1295,7 +1295,7 @@ in extensions, wn is left pointing at the first word not parsed as a command.
             verb_wordnum = usual_grammar_after;
             jump AlmostReParse;
         }
-				m = wn; ! Save wn so extension authors can parse command errors if they want to
+        m = wn; ! Save wn so extension authors can parse command errors if they want to
         wn = 1;
         while ((wn <= num_words) && (NextWord() ~= comma_word)) ;
         parser_results-->ACTION_PRES = ##Answer;
@@ -1304,7 +1304,7 @@ in extensions, wn is left pointing at the first word not parsed as a command.
         parser_results-->INP2_PRES = 1; special_number1 = special_word;
         actor = player;
         consult_from = wn; consult_words = num_words-consult_from+1;
-				wn = m; ! Restore wn so extension authors can parse command errors if they want to
+        wn = m; ! Restore wn so extension authors can parse command errors if they want to
         rtrue;
     }
 


### PR DESCRIPTION
When constructing games which are more like SUSPENDED, where the player is ordering a lot of other characters around a lot, who usually follow the player's orders (are compliant characters), it is helpful to have thorough parsing and error messages for commands given to other characters.  Most of the parsing work is already done in Inform, but the default is to drop the errors and convert it into a generic conversational quip with the Answer action.  Most of the work necessary to identify and report the parser errors can be written in an extension, and I have been writing exactly such an extension, Compliant Characters.i7x.  However, in order to properly produce parser errors, it's necessary to have a hook to tell where the parser stopped being able to parse the command.  

The key piece of information, wn, is unfortunately overwritten in the current codebase before the Inform 7 code can get to it.  This saves wn around the place where it's overwritten and restores it before passing to the Answer code, so that extensions such as my own can access it.

Resetting wn should have no impact on games or extensions which are not trying to do this sort of error parsing; normal games which are using the Answer action for its usual function will use code referring to consult_from and consult_words, not wn.  However, getting wn as it was when the parsing failed turns out to be critical for properly reporting errors in commands like "JOHN, GET THE BOX FWERG".

With this patch my Compliant Characters extension works properly, and as far as I can tell, nothing else breaks, because nothing else was looking at wn in this situation and at this time.