### PR TITLE
fix for GH-Inform7-bugs 9: showme contents of incorprated containers bug

### DIFF
--- a/inform7/Internal/Inter/WorldModelKit/Sections/Tests.i6t
+++ b/inform7/Internal/Inter/WorldModelKit/Sections/Tests.i6t
@@ -272,10 +272,10 @@ current room, or a named item.
 		}
 	}
 	print "^";
-	if (obj.component_child) c = c | ShowMeRecursively(obj.component_child, depth+2, f);
+        if (obj.component_child) c = c | ShowMeRecursively(obj.component_child, depth+2, f);
+	if (child(obj)) c = c | ShowMeRecursively(child(obj), depth+2, f);
 	if ((depth>0) && (obj.component_sibling))
 		c = c | ShowMeRecursively(obj.component_sibling, depth, f);
-	if (child(obj)) c = c | ShowMeRecursively(child(obj), depth+2, f);
 	if ((depth>0) && (sibling(obj))) c = c | ShowMeRecursively(sibling(obj), depth, f);
 	return c;
 ];


### PR DESCRIPTION
per https://github.com/i7/inform7-bugs/issues/9 this code:

```
Test is a room.

A desk is a supporter in Test.
Left drawer and right drawer are containers part of the desk.
Some documents are in the left drawer.
A banana is in the right drawer.
```

results in 

```
>showme desk
desk - supporter
    Left drawer (part of desk) - open container
    right drawer (part of desk) - open container
        banana
        documents
```
This fix makes that
```
>showme desk
desk - supporter
    Left drawer (part of desk) - open container
        documents
    right drawer (part of desk) - open container
        banana
```