### PR TITLE
switched on duck typing

### DIFF
--- a/inform7/extensions/standard_rules/Sections/Actions.w
+++ b/inform7/extensions/standard_rules/Sections/Actions.w
@@ -1209,7 +1209,7 @@ Carry out examining (this is the examine supporters rule):
 			now examine text printed is true.
 
 Carry out examining (this is the examine devices rule):
-	if the noun is a device:
+	if the noun provides the property switched on:
 		say "[The noun] [are] [if story tense is present tense]currently [end if]switched
 			[if the noun is switched on]on[otherwise]off[end if]." (A);
 		now examine text printed is true.


### PR DESCRIPTION
With this one tweak to the standard rules, one can seamlessly make containers or supporters that work like devices by adding the switched on property. Most of the SR work that way already, checking for the property instead of checking "is of kind device"; this changes the sole exception.