### PR TITLE
After saving check that the savefile isn't empty, fixes I7-2171

### DIFF
--- a/inform7/Internal/Inter/WorldModelKit/Sections/Glulx.i6t
+++ b/inform7/Internal/Inter/WorldModelKit/Sections/Glulx.i6t
@@ -118,27 +118,47 @@ functionality, for reasons which are opaque, but no trouble is caused thereby.
 @h Save The Game Rule.
 
 =
-[ SAVE_THE_GAME_R res fref;
+[ SAVE_THE_GAME_R fref len res;
 	if (actor ~= player) rfalse;
-	fref = glk_fileref_create_by_prompt($01, $01, 0);
-	if (fref == 0) jump SFailed;
-	gg_savestr = glk_stream_open_file(fref, $01, GG_SAVESTR_ROCK);
-	glk_fileref_destroy(fref);
-	if (gg_savestr == 0) jump SFailed;
-	@save gg_savestr res;
-	if (res == -1) {
-		! The player actually just typed "restore". We first have to recover
-		! all the Glk objects; the values in our global variables are all wrong.
-		GGRecoverObjects();
-		glk_stream_close(gg_savestr, 0); ! stream_close
-		gg_savestr = 0;
-		RESTORE_THE_GAME_RM('B'); new_line;
-		rtrue;
+	fref = glk_fileref_create_by_prompt(fileusage_SavedGame, filemode_Write, 0);
+	if (fref) {
+		gg_savestr = glk_stream_open_file(fref, filemode_Write, GG_SAVESTR_ROCK);
+		if (gg_savestr) {
+			@save gg_savestr res;
+			if (res == -1) {
+				! The player actually just typed "restore". We first have to recover
+				! all the Glk objects; the values in our global variables are all wrong.
+				GGRecoverObjects();
+				glk_stream_close(gg_savestr, GLK_NULL);
+				gg_savestr = 0;
+				RESTORE_THE_GAME_RM('B'); new_line;
+				rtrue;
+			}
+			glk_stream_close(gg_savestr, GLK_NULL);
+			gg_savestr = 0;
+			if (res == 0) {
+				! Check that the savefile was actually written - this is mostly to account for browser limits in Parchment
+				if (glk_fileref_does_file_exist(fref)) {
+					gg_savestr = glk_stream_open_file(fref, filemode_Read, GG_SAVESTR_ROCK);
+					if (gg_savestr) {
+						glk_stream_set_position(gg_savestr, 0, seekmode_End);
+						len = glk_stream_get_position(gg_savestr);
+						glk_stream_close(gg_savestr, GLK_NULL);
+						gg_savestr = 0;
+						if (len) {
+							! We've confirmed the file exists and has content, which is about all we can do
+							SAVE_THE_GAME_RM('B'); new_line;
+							glk_fileref_destroy(fref);
+							rtrue;
+						}
+						! Cleanup the empty file
+						glk_fileref_delete_file(fref);
+					}
+				}
+			}
+		}
+		glk_fileref_destroy(fref);
 	}
-	glk_stream_close(gg_savestr, 0); ! stream_close
-	gg_savestr = 0;
-	if (res == 0) { SAVE_THE_GAME_RM('B'); new_line; rtrue; }
-	.SFailed;
 	SAVE_THE_GAME_RM('A'); new_line;
 ];
 


### PR DESCRIPTION
After saving check that the savefile isn't empty. This is mostly to account for browser limits in Parchment/Quixe.

I also updated the function to use Glk constants rather than magic numbers, and replaced the jumps with larger if statements as it's easier to read that way IMO.

We should consider adding similar code for data files, transcripts etc. (or maybe abstracting to a utility function.)