### PR TITLE
Modifications to support the advice pages on Linux

### DIFF
--- a/resources/Documentation/Advice/AdviceMaterialsFolder-linux.html
+++ b/resources/Documentation/Advice/AdviceMaterialsFolder-linux.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+{include-css}
+<style type="text/css">
+.red
+\{
+    color:rgb(255,0,0);
+\}
+</style>
+<title>Materials Folder</title>
+</head>
+<body>
+<p><span class="headingpaneltext">Materials Folder</span></p>
+<p>Every project has a &quot;.materials&quot; folder, which is always stored next to it on disc. (Use Ctrl+Shift+M to show the current project's .materials in the Files app.) This diagram shows how the .materials folder would look for a project which used it in every possible way. In practice, this is very unlikely.</p>
+
+<img src="MaterialsDiagram.png" width="275" height="403"/>
+
+<p>Project (<span class="red">1</span>) and .materials folder (<span class="red">2</span>) live side by side in the Files app: everything else here is inside .materials (<span class="red">2</span>). The author of this story decided that it should be given to players along with a PDF booklet (<span class="red">3</span>), by including this Release instruction in the source text:
+
+<blockquote>
+    Release along with a file of &quot;A Guide to Arboreal Fauna&quot; called &quot;A Guide to Arboreal Fauna.pdf&quot;.
+</blockquote>
+
+<p>Every released project needs cover art. Authors have to provide two files, full-sized at 960 by 960 (<span class="red">4</span>) and reduced at 120 by 120 (<span class="red">18</span>): they can either be &quot;Cover.jpg&quot; and &quot;Small Cover.jpg&quot; or &quot;Cover.png&quot; and &quot;Small Cover.png&quot;.</p>
+
+<p>Extensions to Inform are usually centrally installed, and available to all projects. But this project has its own private copy of &quot;Feeding Squirrels by Emily Short&quot; (<span class="red">7</span>), in its own private Extensions folder (<span class="red">5</span>). This would override any installed copy of the same extension. It has to have the correct name and .i7x ending, and it has to live inside a folder with its author's name (<span class="red">6</span>).</p>
+
+<p>Projects which include pictures as well as text need to store the necessary images, in JPEG or PNG format, in the Figures folder (<span class="red">8</span>). This one was declared in the source text like so:</p>
+
+<blockquote>
+    Figure of Red Admiral Butterfly is the file &quot;butterfly.jpg&quot;.
+</blockquote>
+
+<p>Sound effects are similar, use AIFF or OGG format, and live in Sounds (<span class="red">19</span>). There's one here (<span class="red">20</span>), declared by:</p>
+
+<blockquote>
+    Sound of Rustling Leaves is the file &quot;Rustling Leaves.aiff&quot;.
+</blockquote>
+
+<p>Projects which read or write files of data as they play should have a Files folder (<span class="red">10</span>) to hold these. This one (<span class="red">11</span>) was declared by:
+
+<blockquote>
+    The File of Nut Storage Locations is called &quot;nutstorage&quot;.
+</blockquote>
+
+<p>Now for some expert-only features which hardly anybody needs in practice. The I6T folder (<span class="red">12</span>) provides extra template files (<span class="red">13</span>), or indeed replacement ones (<span class="red">14</span>), and allows a project to include substantial portions of raw Inform 6 code. The Languages folder (<span class="red">16</span>) is for experimenting with language bundles, a feature still in its early stages. The Templates folder (<span class="red">21</span>) is for providing the project with a non-standard Javascript engine, called an &quot;interpreter&quot;, when it's released as a website. Here there's an intepreter called &quot;Experimental&quot; (<span class="red">22</span>) which can be selected by putting this into the source:</p>
+
+<blockquote>
+    Release along with the &quot;Experimental&quot; interpreter.
+</blockquote>
+
+<p>And that just leaves the Release folder (<span class="red">17</span>). Inform creates this automatically if the project's Release button is clicked, and then writes into it whatever will eventually go out to players. So never store anything permanent here: it's intended to be just a holding area.
+</p>
+<hr style="margin-top: 18px;">
+</body>
+</html>

--- a/resources/Documentation/Advice/AdviceNewToInform-linux.html
+++ b/resources/Documentation/Advice/AdviceNewToInform-linux.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+{include-css}
+<title>New To Inform?</title>
+</head>
+<body>
+<p><span class="headingpaneltext">New To Inform?</span></p>
+<p>Inform is both an application and a language for creating text-based
+interactive stories. Interactive fiction is an art form which evolved out of the
+adventure games of the 1970s, in the same way that today's graphic novels
+evolved out of the newspaper cartoons of the 1930s. Inform has been the design
+tool of choice for many, indeed most, of the world's leading writers in this
+genre since 1993, and is also widely used in education at a variety of levels.
+It's completely free, even when used to create commercial works. Thanks for
+downloading this copy, and we hope you'll enjoy it.</p>
+
+<p>As you've seen, the app begins with a launcher panel. (Bring it back or
+remove it by typing Ctrl+L.) You might like to try clicking Onyx, the smallest
+of the samples, under the &quot;Open a Sample Project&quot; list: it's a very
+short Russian folk-tale. Inform will ask you to choose somewhere on disc to
+store it, and then make a copy there. You can play with this and alter it
+freely, then throw it away when you're done: it's just a copy.</p>
+
+<p>You can have several Inform projects open at once, but each one lives in a
+single window which is divided in half. The left and right sides are called
+&quot;panes&quot; and you can choose what's shown in them with the side tabs: it
+starts out as Source on the left, Documentation on the right.</p>
+
+<p>Inform &quot;translates&quot; the instructions in the Source into a playable
+story. To see that in action, click the Go button for the Onyx project. You'll
+have to wait just a moment - an Inform project is a surprisingly complicated
+thing to make, even when the instructions look short - but then the Story pane
+will open, and you can type in commands as if you were the player. If you're not
+sure what to type, try typing:</p>
+
+<blockquote>
+    TEST ME
+</blockquote>
+
+<p>The Launcher also offers a larger sample project called &quot;Disenchantment
+Bay&quot;, a story about a boat trip in Alaska. Beyond that, there are around
+450 Examples in the Documentation, and by clicking on the &quot;save as
+project&quot; icon you can get playable versions of all of those, too.</p>
+
+<hr style="margin-top: 18px;">
+</body>
+</html>

--- a/resources/Documentation/Advice/AdviceUpgrading-linux.html
+++ b/resources/Documentation/Advice/AdviceUpgrading-linux.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+{include-css}
+<title>Upgrading?</title>
+</head>
+<body>
+<p><span class="headingpaneltext">Upgrading?</span></p>
+
+<p>Between 2016 and 2022, Inform was rewritten from top to bottom, and prepared
+for open-sourcing: that is, for being published as free software which anybody
+can inspect, fix bugs in, or contribute to. The software changed enormously
+as a result, seen from the inside, but for users it remains almost the same
+(except for hundreds of bug fixes).</p>
+
+<p>There are exceptions to this, however, for users who mix their Inform source
+text with low-level I6 code using "Include (- ... -)". Very few users do this
+themselves, but it's more common to make use of extensions which do. Quite a
+few popular extensions have needed to be rewritten for the version 10 Inform,
+and you may therefore need to update your copies of them. The Public Library
+in this app may be a good place to start.</p>
+
+<p>The archive of release notes for Inform, detailing essentially every change
+since 2006, can be found at <a href="https://github.com/ganelson/inform">
+https://github.com/ganelson/inform</a>.<p>
+<hr style="margin-top: 18px;">
+</body>
+</html>

--- a/scripts/inform.mkscript
+++ b/scripts/inform.mkscript
@@ -801,6 +801,7 @@ forcetransferotherinternals:
 {define: transfer-images}
 	mkdir -p $(BUILTINHTML)
 	cp -f resources/Imagery/app_images/Welcome*Background.png $(BUILTINHTML)
+	cp -f resources/Imagery/app_images/Welcome*Banner.png $(BUILTINHTML)
 	{repeat with: SET in: {IMAGESETLIST}}
 	mkdir -p $(BUILTINHTML)/{SET}
 	rm -f $(BUILTINHTML)/{SET}/*
@@ -872,6 +873,7 @@ ifdef ADVICEHTML
 	$(INBUILDX) -preprocess-html-to $(ADVICEHTML) -preprocess-app $(HTMLPLATFORM) -preprocess-html resources/Documentation/Advice/AdviceNewToInform.html
 	$(INBUILDX) -preprocess-html-to $(ADVICEHTML) -preprocess-app $(HTMLPLATFORM) -preprocess-html resources/Documentation/Advice/AdviceUpgrading.html
 	$(INBUILDX) -preprocess-html-to $(ADVICEHTML) -preprocess-app $(HTMLPLATFORM) -preprocess-html resources/Documentation/Advice/TestingTemplate.html
+	cp -f 'resources/Documentation/Advice/MaterialsDiagram.png' $(ADVICEHTML)
 endif
 {end-define}
 


### PR DESCRIPTION
The Linux app doesn't currently have a launcher window that can display
these pages, but I'm working on one. In advance of that, here are Linux
versions of the advice pages.

I also found that 'make integration' didn't install the welcome banner
for the launcher window, nor one of the assets needed for the advice
pages, so this also patches the make script to do so.