### PR TITLE
initial commit patch for I7-2210: wrong rule name

### DIFF
--- a/resources/Documentation/Examples/Aftershock.txt
+++ b/resources/Documentation/Examples/Aftershock.txt
@@ -2,7 +2,7 @@
 (Radios and other devices active when switched on; Aftershock)
 Modifying the rules for examining a device so that all devices have some specific behavior when switched on, which is described at various times.
 
-The built-in behavior of Inform is to print a line after a device is examined, saying whether the item is on or off. This is often inappropriate, and we could simply turn off that behavior in general by instructing Inform to ignore the "examine described devices rule" (see the chapter on rulebooks).
+The built-in behavior of Inform is to print a line after a device is examined, saying whether the item is on or off. This is often inappropriate, and we could simply turn off that behavior in general by instructing Inform to ignore the "examine devices rule" (see the chapter on rulebooks).
 
 Perhaps, though, we would like continue to have a short passage about the action of any switched on device; we'd just like a little more control over what it says from time to time. And in that case, we might change the rule to give a new activity control over that portion of the description:
 
@@ -16,7 +16,7 @@ Perhaps, though, we would like continue to have a short passage about the action
 		if the item is switched on, say "[The item] is switched on.";
 		otherwise say "[The item] is switched off."
 		
-Borrowing from the rulebooks chapter, we can replace the standard "examine described devices" rule with something that uses this activity. 
+Borrowing from the rulebooks chapter, we can replace the standard "examine devices" rule with something that uses this activity. 
 
 	{**}The new described devices rule is listed instead of the examine devices rule in the carry out examining rules.
 

--- a/resources/Documentation/The Recipe Book.txt
+++ b/resources/Documentation/The Recipe Book.txt
@@ -1126,7 +1126,7 @@ By default, examining an object shows its description, and - for devices - tells
 
 This kind of additional information is not always what we want, so if we have a device whose on/off status we want to conceal, we may write
 
-	The examine described devices rule is not listed in any rulebook.
+	The examine devices rule is not listed in any rulebook.
 
 On the other hand, there are times when we may want to add a similar line or two to the descriptions of other kinds of objects. <b>Crusoe</b> allows us to append an "It is charred." sentence to the end of descriptions of things we have burned in the fire. Since it works by introducing a "printing the description" activity, Crusoe is also a good example to start from if we want to introduce more complex, flexible descriptions of items throughout our story.
 


### PR DESCRIPTION
For [Bug-creating typo in Recipe Book- "The examine described devices rule is not listed in any rulebook."](https://inform7.atlassian.net/browse/I7-2210)