### PR TITLE
remove gap before table body

### DIFF
--- a/indoc/Materials/base.css
+++ b/indoc/Materials/base.css
@@ -132,6 +132,12 @@ td.quotedtablecell {
 	right-margin: 24px;
 }
 
+/* remove gap between table name and body */
+
+table.codetable {
+	margin-top: -1em;
+}
+
 /* ------------------------------------------------------------------------ */
 /* Example cues */
 


### PR DESCRIPTION
a fix for [I7-2214: indoc's output shows an extra blank line following table names in code.](https://inform7.atlassian.net/browse/I7-2214)