### PR TITLE
Remove WINDOWS_JAVASCRIPT, put back JAVASCRIPTPRELUDE

### DIFF
--- a/inblorb/Chapter 1/Main.w
+++ b/inblorb/Chapter 1/Main.w
@@ -11,6 +11,7 @@ values here aren't actually correct for any platform as they stand: in the
 
 =
 wchar_t *FONT_TAG = L"size=2"; /* contents of a |<font>| tag */
+wchar_t *JAVASCRIPT_PRELUDE = L"javascript:window.Project."; /* calling prefix */
 int escape_openUrl = FALSE, escape_fileUrl = FALSE;
 int reverse_slash_openUrl = FALSE, reverse_slash_fileUrl = FALSE;
 
@@ -158,11 +159,11 @@ slashes -- useful if the separation character is a backslash, as on Windows,
 since backslashes are escape characters in Javascript literals.
 
 @<Set platform-dependent HTML and Javascript variables@> =
-	#ifndef WINDOWS_JAVASCRIPT
+	#ifndef PLATFORM_WINDOWS
 		FONT_TAG = L"face=\"lucida grande,geneva,arial,tahoma,verdana,helvetica,helv\" size=2";
 		escape_openUrl = TRUE; /* we want |openUrl| to escape, and |fileUrl| not to */
 	#endif
-	#ifdef WINDOWS_JAVASCRIPT
+	#ifdef PLATFORM_WINDOWS
 		reverse_slash_openUrl = TRUE; reverse_slash_fileUrl = TRUE;
 	#endif
 

--- a/inblorb/Chapter 3/Placeholders.w
+++ b/inblorb/Chapter 3/Placeholders.w
@@ -52,6 +52,7 @@ void Placeholders::initialise(void) {
 	Placeholders::set_to(I"GENERATOR", V, 0);
 	Placeholders::set_to(I"BASE64_TOP", I"", 0);
 	Placeholders::set_to(I"BASE64_TAIL", I"", 0);
+	Placeholders::set_to(I"JAVASCRIPTPRELUDE", Str::literal(JAVASCRIPT_PRELUDE), 0);
 	Placeholders::set_to(I"FONTTAG", Str::literal(FONT_TAG), 0);
 	Placeholders::set_to(I"MATERIALSFOLDERPATHOPEN", I"", 0);
 	Placeholders::set_to(I"MATERIALSFOLDERPATHFILE", I"", 0);

--- a/services/html-module/Chapter 2/Paste Buttons.w
+++ b/services/html-module/Chapter 2/Paste Buttons.w
@@ -199,7 +199,7 @@ void PasteButtons::open_file(OUTPUT_STREAM, pathname *P, text_stream *leaf, char
 	if (leaf) WRITE_TO(fn, "%f", Filenames::in(P, leaf));
 	else WRITE_TO(fn, "%p", P);
 
-	#ifdef WINDOWS_JAVASCRIPT
+	#ifdef PLATFORM_WINDOWS
 	LOOP_THROUGH_TEXT(pos, fn) if (Str::get(pos) == '\\') Str::put(pos, '/');
 	#endif
 


### PR DESCRIPTION
Remove WINDOWS_JAVASCRIPT, put back JAVASCRIPTPRELUDE as needed to generate correct results page for release with old compiler versions