### PR TITLE
Deactivate clarification

### DIFF
--- a/inform7/Internal/Inter/CommandParserKit/Sections/Parser.i6t
+++ b/inform7/Internal/Inter/CommandParserKit/Sections/Parser.i6t
@@ -98,6 +98,8 @@ Global hb_wn;                       ! left over?  (And a save value for wn.)
 Global usual_grammar_after;         ! Point from which usual grammar is parsed (it may vary from
                                     ! the above if user's routines match multi-word verbs)
 
+Global dont_ask_for_clarification;  ! Allows deactivating clarification question
+
 @h Grammar Token Variables.
 More globals, but dealing at the level of individual tokens now.
 
@@ -1750,7 +1752,7 @@ Parse an object name.
         #Ifdef DEBUG;
         if (parser_trace >= 3) print "  [Calling NounDomain on location and actor]^";
         #Endif; ! DEBUG
-        l = NounDomain(actors_location, actor, token);
+        l = NounDomain(actors_location, actor, token, dont_ask_for_clarification);
         if (l == REPARSE_CODE) return l;                  ! Reparse after Q&A
         if (indef_wanted == INDEF_ALL_WANTED && l == 0 && number_matched == 0)
             l = 1;  ! ReviseMulti if TAKE ALL FROM empty container
@@ -1834,7 +1836,7 @@ Parse an object name.
     ! Case 2: token is "held" (which fortunately can't take multiple objects)
     ! and may generate an implicit take
 
-        l = NounDomain(actor,actors_location,token);       ! Same as above...
+        l = NounDomain(actor,actors_location,token,dont_ask_for_clarification);       ! Same as above...
         if (l == REPARSE_CODE) return l;
         if (l == 0) {
             if (indef_possambig) {

--- a/inform7/Tests/Test Cases/Clarified.txt
+++ b/inform7/Tests/Test Cases/Clarified.txt
@@ -12,4 +12,8 @@ After dropping:
  now no-clarifications is true;
  continue the action.
 
-Test me with "get box / red / drop box / l / get box / i".
+After taking the blue box:
+ now no-clarifications is false;
+ continue the action.
+
+Test me with "get box / red / drop box / l / get box / i / get blue box / drop box".

--- a/inform7/Tests/Test Cases/Clarified.txt
+++ b/inform7/Tests/Test Cases/Clarified.txt
@@ -1,0 +1,15 @@
+"The Clarified Ancients of Mu Mu"
+
+Lab is a room.
+
+no-clarifications is a truth state that varies.
+The no-clarifications variable translates into Inter as "dont_ask_for_clarification".
+
+The red box is a thing in the Lab.
+The blue box is a thing in the Lab.
+
+After dropping:
+ now no-clarifications is true;
+ continue the action.
+
+Test me with "get box / red / drop box / l / get box / i".

--- a/inform7/Tests/Test Cases/_Results_Ideal/Clarified.txt
+++ b/inform7/Tests/Test Cases/_Results_Ideal/Clarified.txt
@@ -30,4 +30,10 @@
   You are carrying:
     a red box
   
+  >[7] get blue box
+  Taken.
+  
+  >[8] drop box
+  Which do you mean, the blue box or the red box?
+  
 > >

--- a/inform7/Tests/Test Cases/_Results_Ideal/Clarified.txt
+++ b/inform7/Tests/Test Cases/_Results_Ideal/Clarified.txt
@@ -1,0 +1,33 @@
+   Lab
+  The Clarified Ancients of Mu Mu
+  An Interactive Fiction
+  Release 1 / Serial number 160428 / Inform 7 v10.2.0 / D
+  
+  Lab
+  You can see a red box and a blue box here.
+  
+> >   Lab
+  (Testing.)
+  
+  >[1] get box
+  Which do you mean, the red box or the blue box?
+  
+  >[2] red
+  Taken.
+  
+  >[3] drop box
+  (the red box)
+  Dropped.
+  
+  >[4] l
+  Lab
+  You can see a red box and a blue box here.
+  
+  >[5] get box
+  Taken.
+  
+  >[6] i
+  You are carrying:
+    a red box
+  
+> >


### PR DESCRIPTION
This is a very small change that adds one global to the parser, `dont_ask_for_clarification`, which Parse Token Letter D passes to NounDomain as its fourth parameter (currently Parse Token Letter D omits the fourth parameter).

This offers I7 control of  NounDomain's existing feature to suppress the clarification request. It's a low-cost and safe change that offers a useful feature. (This is inspired by the needs of a particular extension, Object Matching by Xavid, on which a Remembering extension I'm working on depends -- replacing all of ParseToken__ within an extension to change two lines is onerous. Remembering by Aaron Reed didn't work in 6M62, so this functionality hasn't been available for a while. But it seems like something someone else could find further use for in the future.)