### PR TITLE
consistent names between examples and recipe book; making Clark2 standalone

### DIFF
--- a/resources/Documentation/Examples/Clark2.txt
+++ b/resources/Documentation/Examples/Clark2.txt
@@ -6,7 +6,28 @@ Report rules can be a good point at which to add local color: while Inform provi
 
 For instance, if we wanted to liven up our previous Clark Kent example:
 	
-	{*}Report Clark Kent going a direction (called the way):
+	{*}"The Man of Steel Excuses Himself"
+
+	Escaping is an action applying to nothing.
+
+	Carry out someone escaping:
+		let space be the holder of the person asked;
+		let place be a random room which is adjacent to the space;
+		let way be the best route from the space to the place;
+		try the person asked going way.
+	
+	Every turn:
+		if Clark Kent can see kryptonite, try Clark Kent escaping.
+	
+	The Daily Planet Newsroom is a room. 
+
+	Perry White's Office is west of the Newsroom. In Perry White's Office are a desk and a poster of Elvis. On the desk is a lead-lined box. The box is openable. In the box is the green kryptonite crystal.
+
+	The Supply Closet is east of the Newsroom. The Elevator Bank is north of the Newsroom.
+
+	Clark Kent is a man in the Newsroom. "Clark [if Clark can see the kryptonite]looks a bit ill[otherwise]is here, frowning as he revises his latest article[end if]."
+	
+	Report Clark Kent going a direction (called the way):
 		say "[one of]With a particularly weak excuse[or]Muttering[at random] about [random excuse subject], Clark heads [way]." instead.
 
 	To say random excuse subject:
@@ -23,7 +44,9 @@ For instance, if we wanted to liven up our previous Clark Kent example:
 	"wondering where Lois got to"
 	"needing to speak to Jimmy"
 	"noticing the Good Year blimp"
-	
+
+	Test me with "west / get box / east / close box / east / west / north / south / west".
+
 It's good to be careful, as the library report rules have been designed and tested to describe every contingency (going through doors, going in vehicles, etc.): so when replacing a report rule, we should try to consider all the possible variations of the action that we might want to describe. 
 
 However, in this case, our scenario is so simple that there are no doors, vehicles, or pushable objects, so we're safe in giving Clark a very simple reporting scheme.

--- a/resources/Documentation/Examples/Deadbolt.txt
+++ b/resources/Documentation/Examples/Deadbolt.txt
@@ -1,10 +1,10 @@
 ** Locks and keys
-(Deadbolted door unlockable without a key on one side; Neighborhood Watch)
+(Deadbolted door unlockable without a key on one side; Neighbourhood Watch)
 A locked door that can be locked or unlocked without a key from one side, but not from the other.
 
 Suppose we want a locked door that can be opened with a key, but is also openable by hand without a key from one side only. We start by defining an ordinary lockable door and the key that controls it:
 
-	{*}"Neighborhood Watch"
+	{*}"Neighbourhood Watch"
 	
 	The shabby door is a door. It is outside from the Studio Apartment and inside from the Rickety Stairwell. The shabby door is locked.
 

--- a/resources/Documentation/Examples/Meteor.txt
+++ b/resources/Documentation/Examples/Meteor.txt
@@ -1,5 +1,5 @@
 ** Moving things
-(Moving a backdrop during play; Meteoric I and II)
+(Moving a backdrop during play; Meteoric)
 A meteor in the night sky which is visible from many rooms, so needs to be a backdrop, but which does not appear until 11:31 PM.
 
 The game below begins at half past eleven, and one turn later, it's meteor time:

--- a/resources/Documentation/The Recipe Book.txt
+++ b/resources/Documentation/The Recipe Book.txt
@@ -251,7 +251,7 @@ We can pre-empt items from appearing in this paragraph or change their listing b
 			say "The watch catches your eye."; 
 			now the watch is not marked for listing.
 
-If we wanted the watch always to be listed this way, it would be better to give it an initial appearance, but for conditional cases, the listing nondescript items activity is a good place to intervene. For instance, <b>Rip</b> uses this activity to incorporate changeable or portable items into the main description text for a room when (and only when) that is appropriate.
+If we wanted the watch always to be listed this way, it would be better to give it an initial appearance, but for conditional cases, the listing nondescript items activity is a good place to intervene. For instance, <b>Rip Van Winkle</b> uses this activity to incorporate changeable or portable items into the main description text for a room when (and only when) that is appropriate.
 
 The listing nondescript items activity also allows us to replace the "You can see..." tag with something else more fitting, if for instance we are in a dimly lit room.
 
@@ -1898,7 +1898,7 @@ The examples below are therefore mostly ways to get around the usual restriction
 
 <b>U-Stor-It</b> provides a way to have containers with a lid which is also a supporter.
 
-<b>Swigmore</b> provides a supporter which holds up the player, but has no top surface as such, and cannot hold up anything else. <b>Kiwi</b> demonstrates a kind of high shelf, whose objects cannot be seen or used unless the player stands on a ladder.
+<b>Swigmore U.</b> provides a supporter which holds up the player, but has no top surface as such, and cannot hold up anything else. <b>Kiwi</b> demonstrates a kind of high shelf, whose objects cannot be seen or used unless the player stands on a ladder.
 
 <b>Princess and the Pea</b> shows how a pile of supporters, each on top of the last, could be managed.
 


### PR DESCRIPTION
One thing my web doc remix does is makes the bolded names of examples in the Recipe Book links to the actual example. I needed special-casing for some inconsistencies:

- "Meteoric" in RB vs. "Meteoric I and II" in Meteor.txt
- "Neighbourhood Watch" in RB vs. "Neighborhood Watch" in Deadbolt.txt
- "Swigmore" in RB vs. "Swigmore U." in SwigmoreU.txt
- "Rip" in RB vs. "Rip Van Winkle" in Rip.txt

This change standardizes on:
- "Meteoric"
- "Neighbourhood Watch"
- "Swigmore U."
- "Rip Van Winkle"

It also adds the relevant code from ClarkEscape.txt to Clark2.txt to make it compile as a stand-alone example.

(These are things that probably weren't bothering anyone else and, so, are somewhat self-indulgent to ask to have included, but I'm hoping you'll consider them changes in a positive direction, however small.)