### PR TITLE
Add an EditorConfig file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,23 @@
+# EditorConfig is awesome: https://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+[*]
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = false
+insert_final_newline = false
+
+[*.{i6t,w}]
+indent_style = tab
+
+[*.json]
+indent_style = space
+indent_size = 4
+
+[inform7/Tests/Test Cases/*.txt]
+indent_style = tab
+
+[resources/Documentation/**.txt]
+indent_style = tab


### PR DESCRIPTION
Add an EditorConfig file. See https://editorconfig.org

I was getting frustrated by the inconsistent tabs vs spaces in many files (as well as that my editor would default to spaces rather than tabs.) EditorConfig is a standard file supported by almost all editors, which should help us be much more consistent. I added a number of the file formats that I knew are used here, but there are no doubt more that can be added later. Note that it can specify rules either for a file type or for a full path, or a combination of the two. So if, for example, there are some C files that use spaces and some that use tabs, we can specify the rules using paths.