### PR TITLE
Better avoidance of warnings from printing stack frame pointer

### DIFF
--- a/inform7/imperative-module/Chapter 3/Stack Frames.w
+++ b/inform7/imperative-module/Chapter 3/Stack Frames.w
@@ -413,7 +413,7 @@ void Frames::emit_new_local_value(kind *K) {
 void Frames::log(stack_frame *frame) {
 	if (frame == NULL) { LOG("<null stack frame>\n"); return; }
 	LOG("Stack frame at %08x: it:%s, dpc:%s\n",
-		(int)frame,
+		(unsigned int)(pointer_sized_int)frame,
 		(frame->local_variables.it_variable_exists)?"yes":"no",
 		(frame->determines_past_conditions)?"yes":"no");
 	local_variable *lvar;


### PR DESCRIPTION
When printing stack frame address, first cast to uint_ptr and then unsigned integer to avoid warnings