### PR TITLE
Startup rules

### DIFF
--- a/inform7/Internal/Inter/BasicInformKit/Sections/Utilities.i6t
+++ b/inform7/Internal/Inter/BasicInformKit/Sections/Utilities.i6t
@@ -63,6 +63,7 @@ helpful code here: the fallbacks here are basic.
 
 =
 [ PLATFORM_SPECIFIC_STARTUP_R addr res;
+	rfalse;
 ];
 
 [ DebugAction a anames str;

--- a/inform7/Tests/Test Internals/_Results_Ideal/Index-Chart.txt
+++ b/inform7/Tests/Test Internals/_Results_Ideal/Index-Chart.txt
@@ -958,7 +958,7 @@ Rooms are arranged in a map.<br>
 world that is not a room. People, pieces of scenery, furniture, doors and
 mislaid umbrellas might all be examples, and so might more surprising things
 like the sound of birdsong or a shaft of sunlight.<br>
-<i>Usually</i> unlit <i>not</i> lit, inedible <i>not</i> edible, portable <i>not</i> fixed in place, described <i>not</i> undescribed, unmarked for listing <i>not</i> marked for listing, mentioned <i>not</i> unmentioned.<br>
+<i>Usually</i> unlit <i>not</i> lit, inedible <i>not</i> edible, portable <i>not</i> fixed in place, described <i>not</i> undescribed, unmarked for listing <i>not</i> marked for listing, unmentioned <i>not</i> mentioned.<br>
 <i>Usually not</i> scenery, wearable, pushable between rooms, handled.<br>
 <i>Can have</i> description (<i>text</i>), initial appearance (<i>text</i>), matching key (<i>object</i>).<br>
 </p>

--- a/inform7/extensions/standard_rules/Sections/Variables and Rulebooks.w
+++ b/inform7/extensions/standard_rules/Sections/Variables and Rulebooks.w
@@ -488,10 +488,7 @@ Z-machine interpreters such as InfoTaskForce and Zip it was a necessity because
 of the way they buffered output. On modern windowed ones it still helps to
 space the opening text better.
 
-(b) The "position player in model world rule" completes the initial
-construction of the spatial model world.
-
-(c) The "update chronological records rule" is described in further detail
+(b) The "update chronological records rule" is described in further detail
 below, since it appears both here and also in the turn sequence rulebook.
 Here it's providing us with a baseline of initial truths from which we can
 later assess conditions such as "the marble door has been open". A subtle
@@ -503,6 +500,9 @@ Dining Room for three turns". It's as if the player teleports into an
 already-existing world, like some Star Trek crewman, just in time for the
 first command.
 
+(c) The "position player in model world rule" completes the initial
+construction of the spatial model world.
+
 (d) The "start in the correct scenes rule" ensures that we start out
 in the correct scenes. (This can't wait, because it's just conceivable
 that somebody has written a rule with a preamble like "When play
@@ -511,16 +511,17 @@ Entire Game begins.) That completes the necessary preliminaries before
 ordinary I7 rules can be run.
 
 =
-The initial whitespace rule is listed first in the after starting the virtual machine rules.
+The initial whitespace rule is listed in the after starting the virtual machine rules.
 The initial whitespace rule translates into Inter as "INITIAL_WHITESPACE_R".
-
-The position player in model world rule is listed in the after starting the virtual machine rules.
-The position player in model world rule translates into Inter as "POSITION_PLAYER_IN_MODEL_R".
 
 The update chronological records rule is listed in the after starting the virtual machine rules.
 The update chronological records rule translates into Inter as "UPDATE_CHRONOLOGICAL_RECORDS_R".
 
-After starting the virtual machine (this is the start in the correct scenes rule):
+The position player in model world rule is listed in the after starting the virtual machine rules.
+The position player in model world rule translates into Inter as "POSITION_PLAYER_IN_MODEL_R".
+
+The start in the correct scenes rule is listed in the after starting the virtual machine rules.
+This is the start in the correct scenes rule:
 	follow the scene changing rules.
 
 @ The remaining rules, though, are fair game for alteration, and as if to


### PR DESCRIPTION
Implement the new startup sequence (https://github.com/ganelson/inform-evolution/pull/22)

Outstanding errors:

- StandardValueAdjectives
    > Problem__ PM_AdjectiveMisapplied
  >--> In the sentence 'if the turn sequence rulebook is empty' (source text, line 81),
    it looks as if you intend 'turn sequence rulebook is empty' to be a
    condition, but that seems to involve applying the adjective 'empty' to a
    nothing based rulebook - and I have no definition of it which would apply
    in that situation. (Try looking it up in the Lexicon part of the Phrasebook
    index to see what definition(s) 'empty' has.)
    I was trying to match this phrase:
      if (turn sequence rulebook is empty - a condition): 
    I recognised:
    turn sequence rulebook is empty = a condition
Problem__ PM_AdjectiveMisapplied
  >--> In the sentence 'if the turn sequence rulebook is not empty' (source
    text, line 82), it looks as if you intend 'turn sequence rulebook is not
    empty' to be a condition, but that seems to involve applying the adjective
    'empty' to a nothing based rulebook - and I have no definition of it which
    would apply in that situation. (Try looking it up in the Lexicon part of
    the Phrasebook index to see what definition(s) 'empty' has.)
    I was trying to match this phrase:
      if (turn sequence rulebook is not empty - a condition): 
    I recognised:
    turn sequence rulebook is not empty = a condition

    This seems to be caused by a nothing based rulebook not validly matching the definition:

    > Definition: a rulebook is empty rather than non-empty if I6 routine "RulebookEmpty" says so (it
contains no rules, so that following it does nothing and makes no decision).