### PR TITLE
Gender options integration

### DIFF
--- a/inform7/Internal/Extensions/Graham Nelson/English Language.i7x
+++ b/inform7/Internal/Extensions/Graham Nelson/English Language.i7x
@@ -77,7 +77,7 @@ To say regarding (D - a description of objects): (-
 To decide if the prior naming context is plural:
 	(- ((prior_named_list >= 2) || (prior_named_noun && prior_named_noun has pluralname)) -).
 
-Section 2 - Preferred printing gender (for interactive fiction language element)
+Section - Preferred printing gender (for interactive fiction language element only)
 
 Prefer neuter gender is a truth state that varies.
 Prefer neuter gender is usually true.
@@ -101,7 +101,7 @@ To decide which grammatical gender is the printing gender for (o - an object):
 	if o is female:
 		decide on feminine gender.
 
-Section 3 - Saying viewpoint pronouns (for interactive fiction language element)
+Section - Saying viewpoint pronouns (for interactive fiction language element only)
 
 To say we:
 	now the prior named object is the player;
@@ -243,7 +243,7 @@ To say Our:
 		-- second person plural: say "Your";
 		-- third person plural: say "Their";
 
-Section 4 - Further pronouns
+Section - Saying item pronouns (for interactive fiction element only)
 
 To say those:
 	say those in the accusative.
@@ -446,6 +446,8 @@ To say They're:
 			-- the neuter gender: say "That";
 	say "['re]".
 
+Section - Saying non-referential pronouns (for interactive fiction element only)
+
 To say It:
 	say "[regarding nothing]It".
 
@@ -469,6 +471,8 @@ To say it's:
 
 To say there's:
 	say "[regarding nothing]there['re]".
+
+Section - Saying possessives (for interactive fiction element only)
 
 To say possessive:
 	let the item be the prior named object;

--- a/inform7/Internal/Extensions/Graham Nelson/English Language.i7x
+++ b/inform7/Internal/Extensions/Graham Nelson/English Language.i7x
@@ -1,4 +1,4 @@
-Version 2 of English Language by Graham Nelson begins here.
+Version 3 of English Language by Graham Nelson begins here.
 
 "To make English the language of play."
 
@@ -77,189 +77,173 @@ To say regarding (D - a description of objects): (-
 To decide if the prior naming context is plural:
 	(- ((prior_named_list >= 2) || (prior_named_noun && prior_named_noun has pluralname)) -).
 
-Section 2 - Saying pronouns (for interactive fiction language element only)
+Section 2 - Preferred printing gender (for interactive fiction language element)
+
+Prefer neuter gender is a truth state that varies.
+Prefer neuter gender is usually true.
+The preferred animate gender is a grammatical gender which varies.
+The preferred animate gender is usually masculine gender.  [Matches old-fashioned English.]
+
+To decide which grammatical gender is the printing gender for (o - an object):
+	[not male or female, always use "it"]
+	if o is not male and o is not female:
+		decide on neuter gender;
+	[neuter and prefer neuter gender, always use "it"]
+	if o is neuter and prefer neuter gender is true:
+		decide on neuter gender;
+	[female and male, use preferred animate gender]
+	if o is female and o is male:
+		decide on preferred animate gender;
+	[classic male; and non-neuter or male overrrides neuter]
+	if o is male:
+		decide on masculine gender;
+	[classic female; and non-neuter or female overrrides neuter]
+	if o is female:
+		decide on feminine gender.
+
+Section 3 - Saying viewpoint pronouns (for interactive fiction language element)
 
 To say we:
 	now the prior named object is the player;
-	if the story viewpoint is first person singular:
-		say "I";
-	if the story viewpoint is second person singular:
-		say "you";
-	if the story viewpoint is third person singular:
-		if the player is male:
-			say "he";
-		otherwise:
-			say "she";
-	if the story viewpoint is first person plural:
-		say "we";
-	if the story viewpoint is second person plural:
-		say "you";
-	if the story viewpoint is third person plural:
-		say "they".
+	if the story viewpoint is:
+		-- first person singular: say "I";
+		-- second person singular: say "you";
+		-- third person singular:
+			if printing gender for the player is:
+				-- the masculine gender: say "he";
+				-- the feminine gender: say "she";
+				-- the neuter gender: say "it";
+		-- first person plural: say "we";
+		-- second person plural: say "you";
+		-- third person plural: say "they";
 
 To say us:
 	now the prior named object is the player;
-	if the story viewpoint is first person singular:
-		say "me";
-	if the story viewpoint is second person singular:
-		say "you";
-	if the story viewpoint is third person singular:
-		if the player is male:
-			say "him";
-		otherwise:
-			say "her";
-	if the story viewpoint is first person plural:
-		say "us";
-	if the story viewpoint is second person plural:
-		say "you";
-	if the story viewpoint is third person plural:
-		say "them".
+	if the story viewpoint is:
+		-- first person singular: say "me";
+		-- second person singular: say "you";
+		-- third person singular:
+			if printing gender for the player is:
+				-- the masculine gender: say "him";
+				-- the feminine gender: say "her";
+				-- the neuter gender: say "it";
+		-- first person plural: say "us";
+		-- second person plural: say "you";
+		-- third person plural: say "them";
 
 To say ours:
 	now the prior named object is the player;
-	if the story viewpoint is first person singular:
-		say "mine";
-	if the story viewpoint is second person singular:
-		say "yours";
-	if the story viewpoint is third person singular:
-		if the player is male:
-			say "his";
-		otherwise:
-			say "hers";
-	if the story viewpoint is first person plural:
-		say "ours";
-	if the story viewpoint is second person plural:
-		say "yours";
-	if the story viewpoint is third person plural:
-		say "theirs".
+	if the story viewpoint is:
+		-- first person singular: say "mine";
+		-- second person singular: say "yours";
+		-- third person singular:
+			if printing gender for the player is:
+				-- the masculine gender: say "his";
+				-- the feminine gender: say "hers";
+				-- the neuter gender: say "its";
+		-- first person plural: say "ours";
+		-- second person plural: say "yours";
+		-- third person plural: say "theirs";
 
 To say ourselves:
 	now the prior named object is the player;
-	if the story viewpoint is first person singular:
-		say "myself";
-	if the story viewpoint is second person singular:
-		say "yourself";
-	if the story viewpoint is third person singular:
-		if the player is male:
-			say "himself";
-		otherwise:
-			say "herself";
-	if the story viewpoint is first person plural:
-		say "ourselves";
-	if the story viewpoint is second person plural:
-		say "yourselves";
-	if the story viewpoint is third person plural:
-		say "themselves".
+	if the story viewpoint is:
+		-- first person singular: say "myself";
+		-- second person singular: say "yourself";
+		-- third person singular:
+			if printing gender for the player is:
+				-- the masculine gender: say "himself";
+				-- the feminine gender: say "herself";
+				-- the neuter gender: say "itself";
+		-- first person plural: say "ourselves";
+		-- second person plural: say "yourselves";
+		-- third person plural: say "themselves";
 
 To say our:
 	now the prior named object is the player;
-	if the story viewpoint is first person singular:
-		say "my";
-	if the story viewpoint is second person singular:
-		say "your";
-	if the story viewpoint is third person singular:
-		if the player is male:
-			say "his";
-		otherwise:
-			say "her";
-	if the story viewpoint is first person plural:
-		say "our";
-	if the story viewpoint is second person plural:
-		say "your";
-	if the story viewpoint is third person plural:
-		say "their".
+	if the story viewpoint is:
+		-- first person singular: say "my";
+		-- second person singular: say "your";
+		-- third person singular:
+			if printing gender for the player is:
+				-- the masculine gender: say "his";
+				-- the feminine gender: say "her";
+				-- the neuter gender: say "its";
+		-- first person plural: say "our";
+		-- second person plural: say "your";
+		-- third person plural: say "their";
 
 To say We:
 	now the prior named object is the player;
-	if the story viewpoint is first person singular:
-		say "I";
-	if the story viewpoint is second person singular:
-		say "You";
-	if the story viewpoint is third person singular:
-		if the player is male:
-			say "He";
-		otherwise:
-			say "She";
-	if the story viewpoint is first person plural:
-		say "We";
-	if the story viewpoint is second person plural:
-		say "You";
-	if the story viewpoint is third person plural:
-		say "They".
+	if the story viewpoint is:
+		-- first person singular: say "I";
+		-- second person singular: say "You";
+		-- third person singular:
+			if printing gender for the player is:
+				-- the masculine gender: say "He";
+				-- the feminine gender: say "She";
+				-- the neuter gender: say "It";
+		-- first person plural: say "We";
+		-- second person plural: say "You";
+		-- third person plural: say "They";
 
 To say Us:
 	now the prior named object is the player;
-	if the story viewpoint is first person singular:
-		say "Me";
-	if the story viewpoint is second person singular:
-		say "You";
-	if the story viewpoint is third person singular:
-		if the player is male:
-			say "Him";
-		otherwise:
-			say "Her";
-	if the story viewpoint is first person plural:
-		say "Us";
-	if the story viewpoint is second person plural:
-		say "You";
-	if the story viewpoint is third person plural:
-		say "Them".
+	if the story viewpoint is:
+		-- first person singular: say "Me";
+		-- second person singular: say "You";
+		-- third person singular:
+			if printing gender for the player is:
+				-- the masculine gender: say "Him";
+				-- the feminine gender: say "Her";
+				-- the neuter gender: say "It";
+		-- first person plural: say "Us";
+		-- second person plural: say "You";
+		-- third person plural: say "Them";
 
 To say Ours:
 	now the prior named object is the player;
-	if the story viewpoint is first person singular:
-		say "Mine";
-	if the story viewpoint is second person singular:
-		say "Yours";
-	if the story viewpoint is third person singular:
-		if the player is male:
-			say "His";
-		otherwise:
-			say "Hers";
-	if the story viewpoint is first person plural:
-		say "Ours";
-	if the story viewpoint is second person plural:
-		say "Yours";
-	if the story viewpoint is third person plural:
-		say "Theirs".
+	if the story viewpoint is:
+		-- first person singular: say "Mine";
+		-- second person singular: say "Yours";
+		-- third person singular:
+			if printing gender for the player is:
+				-- the masculine gender: say "His";
+				-- the feminine gender: say "Hers";
+				-- the neuter gender: say "Its";
+		-- first person plural: say "Ours";
+		-- second person plural: say "Yours";
+		-- third person plural: say "Theirs";
 
 To say Ourselves:
 	now the prior named object is the player;
-	if the story viewpoint is first person singular:
-		say "Myself";
-	if the story viewpoint is second person singular:
-		say "Yourself";
-	if the story viewpoint is third person singular:
-		if the player is male:
-			say "Himself";
-		otherwise:
-			say "Herself";
-	if the story viewpoint is first person plural:
-		say "Ourselves";
-	if the story viewpoint is second person plural:
-		say "Yourselves";
-	if the story viewpoint is third person plural:
-		say "Themselves".
+	if the story viewpoint is:
+		-- first person singular: say "Myself";
+		-- second person singular: say "Yourself";
+		-- third person singular:
+			if printing gender for the player is:
+				-- the masculine gender: say "Himself";
+				-- the feminine gender: say "Herself";
+				-- the neuter gender: say "Itself";
+		-- first person plural: say "Ourselves";
+		-- second person plural: say "Yourselves";
+		-- third person plural: say "Themselves";
 
 To say Our:
 	now the prior named object is the player;
-	if the story viewpoint is first person singular:
-		say "My";
-	if the story viewpoint is second person singular:
-		say "Your";
-	if the story viewpoint is third person singular:
-		if the player is male:
-			say "His";
-		otherwise:
-			say "Her";
-	if the story viewpoint is first person plural:
-		say "Our";
-	if the story viewpoint is second person plural:
-		say "Your";
-	if the story viewpoint is third person plural:
-		say "Their".
+	if the story viewpoint is:
+		-- first person singular: say "My";
+		-- second person singular: say "Your";
+		-- third person singular:
+			if printing gender for the player is:
+				-- the masculine gender: say "His";
+				-- the feminine gender: say "Her";
+				-- the neuter gender: say "Its";
+		-- first person plural: say "Our";
+		-- second person plural: say "Your";
+		-- third person plural: say "Their";
 
-Section 3 - Further pronouns (for interactive fiction language element only)
+Section 4 - Further pronouns
 
 To say those:
 	say those in the accusative.
@@ -274,24 +258,22 @@ To say those in (case - grammatical case):
 			say "those";
 		otherwise if the item is the player:
 			say "[we]";
-		otherwise if the item is a male person and item is not neuter:
-			say "he";
-		otherwise if the item is a female person and item is not neuter:
-			say "she";
 		otherwise:
-			say "that";
+			if printing gender for the item is:
+				-- the masculine gender: say "he";
+				-- the feminine gender: say "she";
+				-- the neuter gender: say "that";
 	otherwise:
 		let the item be the prior named object;
 		if the prior naming context is plural:
 			say "those";
 		otherwise if the item is the player:
 			say "[we]";
-		otherwise if the item is a male person and item is not neuter:
-			say "him";
-		otherwise if the item is a female person and item is not neuter:
-			say "her";
 		otherwise:
-			say "that".
+			if printing gender for the item is:
+				-- the masculine gender: say "him";
+				-- the feminine gender: say "her";
+				-- the neuter gender: say "that";
 
 To say Those in (case - grammatical case):
 	if the case is nominative:
@@ -300,24 +282,22 @@ To say Those in (case - grammatical case):
 			say "Those";
 		otherwise if the item is the player:
 			say "[We]";
-		otherwise if the item is a male person and item is not neuter:
-			say "He";
-		otherwise if the item is a female person and item is not neuter:
-			say "She";
 		otherwise:
-			say "That";
+			if printing gender for the item is:
+				-- the masculine gender: say "He";
+				-- the feminine gender: say "She";
+				-- the neuter gender: say "That";
 	otherwise:
 		let the item be the prior named object;
 		if the prior naming context is plural:
 			say "Those";
 		otherwise if the item is the player:
 			say "[We]";
-		otherwise if the item is a male person and item is not neuter:
-			say "Him";
-		otherwise if the item is a female person and item is not neuter:
-			say "Her";
 		otherwise:
-			say "That";
+			if printing gender for the item is:
+				-- the masculine gender: say "Him";
+				-- the feminine gender: say "Her";
+				-- the neuter gender: say "That";
 
 To say they:
 	let the item be the prior named object;
@@ -325,12 +305,11 @@ To say they:
 		say "they";
 	otherwise if the item is the player:
 		say "[we]";
-	otherwise if the item is a male person and item is not neuter:
-		say "he";
-	otherwise if the item is a female person and item is not neuter:
-		say "she";
 	otherwise:
-		say "it";
+		if printing gender for the item is:
+			-- the masculine gender: say "he";
+			-- the feminine gender: say "she";
+			-- the neuter gender: say "it";
 
 To say They:
 	let the item be the prior named object;
@@ -338,12 +317,11 @@ To say They:
 		say "They";
 	otherwise if the item is the player:
 		say "[We]";
-	otherwise if the item is a male person and item is not neuter:
-		say "He";
-	otherwise if the item is a female person and item is not neuter:
-		say "She";
 	otherwise:
-		say "It";
+		if printing gender for the item is:
+			-- the masculine gender: say "He";
+			-- the feminine gender: say "She";
+			-- the neuter gender: say "It";
 
 To say their:
 	let the item be the prior named object;
@@ -351,12 +329,11 @@ To say their:
 		say "their";
 	otherwise if the item is the player:
 		say "[our]";
-	otherwise if the item is a male person and item is not neuter:
-		say "his";
-	otherwise if the item is a female person and item is not neuter:
-		say "her";
 	otherwise:
-		say "its";
+		if printing gender for the item is:
+			-- the masculine gender: say "his";
+			-- the feminine gender: say "her";
+			-- the neuter gender: say "its";
 
 To say Their:
 	let the item be the prior named object;
@@ -364,12 +341,11 @@ To say Their:
 		say "Their";
 	otherwise if the item is the player:
 		say "[Our]";
-	otherwise if the item is a male person and item is not neuter:
-		say "His";
-	otherwise if the item is a female person and item is not neuter:
-		say "Her";
 	otherwise:
-		say "Its";
+		if printing gender for the item is:
+			-- the masculine gender: say "His";
+			-- the feminine gender: say "Her";
+			-- the neuter gender: say "Its";
 
 To say them:
 	let the item be the prior named object;
@@ -377,12 +353,11 @@ To say them:
 		say "them";
 	otherwise if the item is the player:
 		say "[us]";
-	otherwise if the item is a male person and item is not neuter:
-		say "him";
-	otherwise if the item is a female person and item is not neuter:
-		say "her";
 	otherwise:
-		say "it";
+		if printing gender for the item is:
+			-- the masculine gender: say "him";
+			-- the feminine gender: say "her";
+			-- the neuter gender: say "it";
 
 To say Them:
 	let the item be the prior named object;
@@ -390,12 +365,11 @@ To say Them:
 		say "Them";
 	otherwise if the item is the player:
 		say "[Us]";
-	otherwise if the item is a male person and item is not neuter:
-		say "Him";
-	otherwise if the item is a female person and item is not neuter:
-		say "Her";
 	otherwise:
-		say "It";
+		if printing gender for the item is:
+			-- the masculine gender: say "Him";
+			-- the feminine gender: say "Her";
+			-- the neuter gender: say "It";
 
 To say theirs:
 	let the item be the prior named object;
@@ -403,12 +377,11 @@ To say theirs:
 		say "theirs";
 	otherwise if the item is the player:
 		say "[ours]";
-	otherwise if the item is a male person and item is not neuter:
-		say "his";
-	otherwise if the item is a female person and item is not neuter:
-		say "hers";
 	otherwise:
-		say "its";
+		if printing gender for the item is:
+			-- the masculine gender: say "his";
+			-- the feminine gender: say "hers";
+			-- the neuter gender: say "its";
 
 To say Theirs:
 	let the item be the prior named object;
@@ -416,12 +389,11 @@ To say Theirs:
 		say "Theirs";
 	otherwise if the item is the player:
 		say "[Ours]";
-	otherwise if the item is a male person and item is not neuter:
-		say "His";
-	otherwise if the item is a female person and item is not neuter:
-		say "Hers";
 	otherwise:
-		say "Its";
+		if printing gender for the item is:
+			-- the masculine gender: say "His";
+			-- the feminine gender: say "Hers";
+			-- the neuter gender: say "Its";
 
 To say themselves:
 	let the item be the prior named object;
@@ -429,12 +401,11 @@ To say themselves:
 		say "themselves";
 	otherwise if the item is the player:
 		say "[ourselves]";
-	otherwise if the item is a male person and item is not neuter:
-		say "himself";
-	otherwise if the item is a female person and item is not neuter:
-		say "herself";
 	otherwise:
-		say "itself";
+		if printing gender for the item is:
+			-- the masculine gender: say "himself";
+			-- the feminine gender: say "herself";
+			-- the neuter gender: say "itself";
 
 To say Themselves:
 	let the item be the prior named object;
@@ -442,25 +413,24 @@ To say Themselves:
 		say "Themselves";
 	otherwise if the item is the player:
 		say "[Ourselves]";
-	otherwise if the item is a male person and item is not neuter:
-		say "Himself";
-	otherwise if the item is a female person and item is not neuter:
-		say "Herself";
 	otherwise:
-		say "Itself";
+		if printing gender for the item is:
+			-- the masculine gender: say "Himself";
+			-- the feminine gender: say "Herself";
+			-- the neuter gender: say "Itself";
 
+[Note the difference in the neuter gender between /they're/ -> that's and /they/ /'re/ -> they're]
 To say they're:
 	let the item be the prior named object;
 	if the prior naming context is plural:
 		say "they";
 	otherwise if the item is the player:
 		say "[we]";
-	otherwise if the item is a male person and item is not neuter:
-		say "he";
-	otherwise if the item is a female person and item is not neuter:
-		say "she";
 	otherwise:
-		say "that";
+		if printing gender for the item is:
+			-- the masculine gender: say "he";
+			-- the feminine gender: say "she";
+			-- the neuter gender: say "that";
 	say "['re]".
 
 To say They're:
@@ -469,12 +439,11 @@ To say They're:
 		say "They";
 	otherwise if the item is the player:
 		say "[We]";
-	otherwise if the item is a male person and item is not neuter:
-		say "He";
-	otherwise if the item is a female person and item is not neuter:
-		say "She";
 	otherwise:
-		say "That";
+		if printing gender for the item is:
+			-- the masculine gender: say "He";
+			-- the feminine gender: say "She";
+			-- the neuter gender: say "That";
 	say "['re]".
 
 To say It:

--- a/inform7/Internal/Inter/CommandParserKit/Sections/Parser.i6t
+++ b/inform7/Internal/Inter/CommandParserKit/Sections/Parser.i6t
@@ -3930,12 +3930,39 @@ Manual}, 4th edition.
 @h Pronoun Handling.
 
 =
+Include (-
+[ GetGNABitfield obj g gn;
+  ! First calculate three-bit gender field
+  g = 0;
+  if ( obj has neuter ) {
+    g = g + 1;  ! bit position 0
+    }
+  if ( obj has female ) {
+    g = g + 2;  ! bit position 1
+    }
+  if ( obj has male ) {
+    g = g + 4;  ! bit position 2
+    }
+  gn = 0;
+  if ( obj has ambigpluralname  ) {
+    gn = g * 9;  ! plural in low significant digits, plus singular shifted three to the left
+  } else if ( obj has pluralname ) {
+    gn = gn + g;  ! plural is in low significant digits
+  } else {  ! obj is singular-named
+    gn = gn + g * 8;  ! singular is shifted 3 to the left
+  }
+  if ( obj has animate ) {
+    return gn * 64; ! shift 6 to the left for animate objects
+    }
+  return gn;  ! shift 0
+];
+
 [ SetPronoun dword value x;
     for (x=1 : x<=LanguagePronouns-->0 : x=x+3)
         if (LanguagePronouns-->x == dword) {
             LanguagePronouns-->(x+2) = value; return;
         }
-    RunTimeError(14);
+    RunTimeError(12);
 ];
 
 [ PronounValue dword x;
@@ -3950,20 +3977,19 @@ Manual}, 4th edition.
 [ PronounNotice obj x bm g;
     if (obj == player) return;
 
-	g = (GetGNAOfObject(obj));
-
-    bm = PowersOfTwo_TB-->g;
+    bm = GetGNABigfield(obj);
     for (x=1 : x<=LanguagePronouns-->0 : x=x+3)
         if (bm & (LanguagePronouns-->(x+1)) ~= 0)
             LanguagePronouns-->(x+2) = obj;
+];
 
-	if (((g % 6) < 3) && (obj has ambigpluralname)) {
-		g = g + 3;
-		bm = PowersOfTwo_TB-->g;
-		for (x=1 : x<=LanguagePronouns-->0 : x=x+3)
-			if (bm & (LanguagePronouns-->(x+1)) ~= 0)
-				LanguagePronouns-->(x+2) = obj;
-	}
+[ PronounUnNotice obj x bm;
+    if (obj == player) return;
+
+    bm = GetGNABitfield(obj);
+    for (x=1 : x < (LanguagePronouns-->0 - 2) : x=x+3)
+        if ((bm & (LanguagePronouns-->(x+1)) == 0) && (LanguagePronouns-->(x+2) == obj))
+            LanguagePronouns-->(x+2) = NULL;
 ];
 
 [ PronounNoticeHeldObjects x;

--- a/inform7/Internal/Inter/CommandParserKit/Sections/Parser.i6t
+++ b/inform7/Internal/Inter/CommandParserKit/Sections/Parser.i6t
@@ -3976,7 +3976,7 @@ Manual}, 4th edition.
 [ PronounNotice obj x bm g;
     if (obj == player) return;
 
-    bm = GetGNABigfield(obj);
+    bm = GetGNABitfield(obj);
     for (x=1 : x<=LanguagePronouns-->0 : x=x+3)
         if (bm & (LanguagePronouns-->(x+1)) ~= 0)
             LanguagePronouns-->(x+2) = obj;

--- a/inform7/Internal/Inter/CommandParserKit/Sections/Parser.i6t
+++ b/inform7/Internal/Inter/CommandParserKit/Sections/Parser.i6t
@@ -3930,7 +3930,6 @@ Manual}, 4th edition.
 @h Pronoun Handling.
 
 =
-Include (-
 [ GetGNABitfield obj g gn;
   ! First calculate three-bit gender field
   g = 0;

--- a/inform7/Internal/Inter/EnglishLanguageKit/Sections/Language.i6t
+++ b/inform7/Internal/Inter/EnglishLanguageKit/Sections/Language.i6t
@@ -81,9 +81,9 @@ Array LanguagePronouns table
   !             s  p  s  p
   !             mfnmfnmfnmfn
 
-    'it'      $$001000111000                    NULL
-    'him'     $$100000000000                    NULL
-    'her'     $$010000000000                    NULL
+    'it'      $$001000001000                    NULL
+    'him'     $$100000100000                    NULL
+    'her'     $$010000010000                    NULL
     'them'    $$000111000111                    NULL;
 
 @h Descriptors.

--- a/inform7/extensions/standard_rules/Sections/Physical World Model.w
+++ b/inform7/extensions/standard_rules/Sections/Physical World Model.w
@@ -696,6 +696,30 @@ A backdrop is usually scenery.
 A backdrop is always fixed in place.
 A backdrop is never pushable between rooms.
 
+@h Gender.
+Gramatical gender is somewhat complex in English, and 19th-century binary
+gender assumptions are not justifiable any more.  Male, female, and neuter are
+three either-or properties (also present in the I6 library), which can be assigned
+independently.  These determine whether the object is matched when the player uses
+the pronoun "he", "she", or "it".  In addition, the "ambiguously plural" property
+determines whether the object is matched when the player uses the pronoun "they".
+
+The defaults follow a principle of least surprise for the player.
+A thing is usually neuter ("it", not "he" or "she").
+However, the story writer can override this as desired
+(making a ship match "she" and "it", for example).
+See below for the defaults for people.
+
+=
+Section 11a - Gender
+An object can be neuter.  An object is usually not neuter.
+An object can be male.  An object is usually not male.
+An object can be female.  An object is usually not female.
+
+A thing is usually neuter.
+A thing is usually not male.
+A thing is usually not female.
+
 @h People.
 From a compilation point of view, people are surprisingly easy to deal with.
 It may well be argued that this is because the I6 world model is so sketchy
@@ -722,21 +746,37 @@ and the valued property |before| to a person, giving that value as just
 (using I6's |ChangePlayer| routine).
 
 =
-Section 11 - People
+Section 11b - People
 
 The specification of person is "Despite the name, not necessarily a human
 being, but anything animate enough to envisage having a conversation with, or
 bartering with."
 
-A person can be female or male. A person is usually male.
-A person can be neuter. A person is usually not neuter.
-
 A person has a number called carrying capacity.
 The carrying capacity of a person is usually 100.
 
-A person can be transparent. A person is always transparent.
+A person can be transparent. A person is usually transparent.
 
-@ One among the people is special: the enigmatic default protagonist, whose
+@h Gender of People
+
+A person without further specifications is usually male and female and
+ambiguously plural (matching "he", "she", or "they", but not "it").
+
+This follows a principle of least surprise for the player: if the player sees
+a mysterious person, they can refer to them as "he", "she", or "they".
+However, the story writer can override this as desired.
+See also the "man" and "woman" kinds below.
+
+=
+Section 11c - Gender of People
+
+A person is usually male.
+A person is usually female.
+A person is usually not neuter.
+A person is usually ambiguously plural.
+
+@h Yourself
+One among the people is special: the enigmatic default protagonist, whose
 name is not "player" but "yourself". (The I6 library requires this object to
 be created as |selfobj|, but that's not a name that is ever printed or parsed:
 it's a constant value used only in I6 source code.)
@@ -757,15 +797,22 @@ player is "your dreary self".") The Inform compiler automatically generates
 that property for the "yourself" object, so we need do nothing here.
 
 =
+Section 11d - Yourself
 The yourself is an undescribed person. The yourself is proper-named.
 
 The yourself is privately-named.
 Understand "your former self" or "my former self" or "former self" or
 	"former" as yourself when the player is not yourself.
 
-The description of yourself is usually "As good-looking as ever."
-
 The yourself object is accessible to Inter as "selfobj".
+
+@h Description of Yourself
+Extension and story writers frequently want to override the description of yourself.
+
+=
+Section 11e - Description of Yourself
+
+The description of yourself is usually "As good-looking as ever."
 
 @h Non-fundamental kinds.
 We have now finished defining the nine fundamental kinds which Inform requires
@@ -819,6 +866,9 @@ children to qualify in these categories.)
 Anyway, we set out the Anglo-Saxon plurals, and then declare these kinds
 purely in terms of gender: they have no distinguishing behaviour.
 
+The gender behavior here is defined with "usually", so that it can be overridden
+if the story author so chooses.
+
 =
 Section 12 - Animals, men and women
 
@@ -826,11 +876,15 @@ The plural of man is men. The plural of woman is women.
 
 A man is a kind of person.
 The specification of man is "Represents a man or boy."
-A man is always male. A man is never neuter.
+A man is usually male.
+A man is usually not female.
+A man is usually not neuter.
 
 A woman is a kind of person.
 The specification of woman is "Represents a woman or girl."
-A woman is always female. A woman is never neuter.
+A woman is usually female.
+A woman is usually not male.
+A woman is usually not neuter.
 
 @ But what about "animal"? Animals turn up often in IF, and of course
 domestic animals have been part of human society since prehistoric times:
@@ -847,11 +901,16 @@ because that sounds like an insistent assertion of rights and thus a quite
 different sort of statement. (Don't drown that Labrador! He's a person.)
 
 As can be seen from the tiny definition of "animal", though, it's really
-nothing more than a name for a position in the kinds hierarchy. There is
-not even any implication for gender.
+nothing more than a name for a position in the kinds hierarchy.
+
+By default an animal is neuter: it responds to "it" but not to "he" or "she".
+As always, this can be overriden by the story author.
 
 =
 An animal is a kind of person.
+An animal is usually not male.
+An animal is usually not female.
+An animal is usually neuter.
 
 The specification of animal is "Represents an animal, or at any rate a
 non-human living creature reasonably large and possible to interact with: a
@@ -1002,6 +1061,7 @@ The undescribed property is defined by Inter as "concealed".
 The edible property is defined by Inter as "edible".
 The enterable property is defined by Inter as "enterable".
 The female property is defined by Inter as "female".
+The male property is defined by Inter as "male".
 The mentioned property is defined by Inter as "mentioned".
 The lit property is defined by Inter as "light".
 The lighted property is defined by Inter as "light".

--- a/inform7/extensions/standard_rules/Sections/Physical World Model.w
+++ b/inform7/extensions/standard_rules/Sections/Physical World Model.w
@@ -701,17 +701,26 @@ Gramatical gender is somewhat complex in English, and 19th-century binary
 gender assumptions are not justifiable any more.  Male, female, and neuter are
 three either-or properties (also present in the I6 library), which can be assigned
 independently.  These determine whether the object is matched when the player uses
-the pronoun "he", "she", or "it".  In addition, the "ambiguously plural" property
-determines whether the object is matched when the player uses the pronoun "they".
+the pronouns HIM, HER, or IT.  In addition, the "ambiguously plural" property
+determines whether the object is matched when the player uses the pronoun THEM.
 
 The defaults follow a principle of least surprise for the player.
-A thing is usually neuter ("it", not "he" or "she").
+A thing is usually neuter: IT, not HIM or HER.
 However, the story writer can override this as desired
-(making a ship match "she" and "it", for example).
+(making a ship match HER and IT, for example).
+
+When the game prints a pronoun, however, it has to pick one.  If a thing is neuter
+as well as male or female, IT will take priority when
+printing pronouns (useful for the aforementioned ship), unless
+"prefer neuter gender" is set to false.  If a thing is male and female, the
+"preferred animate gender" will be used for printing pronouns, which defaults to
+male, but can be changed.  See the English Language extension for more details.
+
 See below for the defaults for people.
 
 =
 Section 11a - Gender
+
 An object can be neuter.  An object is usually not neuter.
 An object can be male.  An object is usually not male.
 An object can be female.  An object is usually not female.
@@ -726,19 +735,6 @@ It may well be argued that this is because the I6 world model is so sketchy
 in modelling them, but that may actually be a good thing, because it's not at
 all obvious that any single model will be sensible for what different
 authors want to do with their characters.
-
-On gender, see also the "man" and "woman" kinds below. Note that we have
-three gender choices available -- male, female and neuter -- but these are,
-for historical reasons to do with how gender is handled by the I6 library,
-managed using either/or properties rather than a single three-way value
-property. This doesn't in practice cause trouble. (Specifying something as
-neuter overrides the male/female choice, if anyone does both for the same
-object, but in practice nobody does.) When nothing is said about a person's
-gender, it is assumed male, though this is used only linguistically (for
-instance, the pronoun HIM can be used in commands about the object, rather
-than HER or IT). There has to be some convention here, and in a case where
-we don't know our linguistic ground, opting for the least surprising
-behaviour seems wisest.
 
 The Inform compiler automatically applies the either-or property |animate|
 and the valued property |before| to a person, giving that value as just
@@ -760,12 +756,16 @@ A person can be transparent. A person is usually transparent.
 @h Gender of People
 
 A person without further specifications is usually male and female and
-ambiguously plural (matching "he", "she", or "they", but not "it").
+ambiguously plural (matching HIM, HER, or THEM, but not IT).
 
 This follows a principle of least surprise for the player: if the player sees
-a mysterious person, they can refer to them as "he", "she", or "they".
+a mysterious person, they can refer to them as HIM, HER, or THEM.
 However, the story writer can override this as desired.
 See also the "man" and "woman" kinds below.
+
+When the game goes to print a pronoun for a generic person, it has to pick one.
+For historical reasons, and to maintain compatibility, it will default to HIM.
+This can be overridden; see the English Language extension for details.
 
 =
 Section 11c - Gender of People
@@ -798,6 +798,7 @@ that property for the "yourself" object, so we need do nothing here.
 
 =
 Section 11d - Yourself
+
 The yourself is an undescribed person. The yourself is proper-named.
 
 The yourself is privately-named.
@@ -867,7 +868,7 @@ Anyway, we set out the Anglo-Saxon plurals, and then declare these kinds
 purely in terms of gender: they have no distinguishing behaviour.
 
 The gender behavior here is defined with "usually", so that it can be overridden
-if the story author so chooses.
+if the story author so chooses.  A man will match "HIM" and a woman will match "HER".
 
 =
 Section 12 - Animals, men and women
@@ -905,7 +906,7 @@ different sort of statement. (Don't drown that Labrador! He's a person.)
 As can be seen from the tiny definition of "animal", though, it's really
 nothing more than a name for a position in the kinds hierarchy.
 
-By default an animal is neuter: it responds to "it" but not to "he" or "she".
+By default an animal is neuter, matching only IT.
 As always, this can be overriden by the story author.
 
 =

--- a/inform7/extensions/standard_rules/Sections/Physical World Model.w
+++ b/inform7/extensions/standard_rules/Sections/Physical World Model.w
@@ -867,7 +867,7 @@ Anyway, we set out the Anglo-Saxon plurals, and then declare these kinds
 purely in terms of gender: they have no distinguishing behaviour.
 
 The gender behavior here is defined with "usually", so that it can be overridden
-if the story author so chooses.  A man is 
+if the story author so chooses.
 
 =
 Section 12 - Animals, men and women

--- a/inform7/extensions/standard_rules/Sections/Physical World Model.w
+++ b/inform7/extensions/standard_rules/Sections/Physical World Model.w
@@ -867,7 +867,7 @@ Anyway, we set out the Anglo-Saxon plurals, and then declare these kinds
 purely in terms of gender: they have no distinguishing behaviour.
 
 The gender behavior here is defined with "usually", so that it can be overridden
-if the story author so chooses.
+if the story author so chooses.  A man is 
 
 =
 Section 12 - Animals, men and women
@@ -879,12 +879,14 @@ The specification of man is "Represents a man or boy."
 A man is usually male.
 A man is usually not female.
 A man is usually not neuter.
+A man is usually not ambiguously plural.
 
 A woman is a kind of person.
 The specification of woman is "Represents a woman or girl."
 A woman is usually female.
 A woman is usually not male.
 A woman is usually not neuter.
+A woman is usually not ambiguously plural.
 
 @ But what about "animal"? Animals turn up often in IF, and of course
 domestic animals have been part of human society since prehistoric times:
@@ -911,6 +913,7 @@ An animal is a kind of person.
 An animal is usually not male.
 An animal is usually not female.
 An animal is usually neuter.
+An animal is usually not ambiguously plural.
 
 The specification of animal is "Represents an animal, or at any rate a
 non-human living creature reasonably large and possible to interact with: a


### PR DESCRIPTION
This is an extremely conservative set of changes.  All but one of the changes here have been in the Gender Options extension for years and it has been used by a signifcant number of games with no problems.
 
The one change not heavily tested is to make a person (but not man, woman, or animal) ambiguously plural by default.  This is correct in English -- you can always refer to an unidentified person as "them", as Chaucer and Shakespeare do.  If this creates irritation in gameplay for a particular game, it can always be turned off for any particular person by the story writer, since it's a "usually".
  
The default gender behavior of Inform is very nearly unchanged -- I went to a lot of effort to do that -- and most story/game writers should notice no differences at all.  Those who have only used "X is a man", "Y is a woman", "Z is an animal", "W is a thing" should find the game working as expected.   

What this does is to open up options for story writers who want to do something more complicated.  By (1) removing assumptions from the I6/Inter code; (2) changing a bunch of "always" and "never" to "usually"; and (3) breaking enormous blocks of standard rules into smaller sections which can be overriden more granularly -- story writers can change things more easily without having to replace half the codebase.

In addition to the changes related to gender, the player is *usually* transparent rather than *always* transparent, solving another difficult-to-override issue.  There is also a fix to a runtime error number.

For more information and background, see the Gender Options.i7x extension.  There are probably substantially larger improvements which could be made in this arena, but these are conservative and well-tested.

Getting these edits into the form of a patch (rather than an extension) took quite a while.  I have not been able to convert the test cases from Gender Options.i7x to Inform test cases yet and I am not sure when I will have the time.