### PR TITLE
neutralizing standard rules

### DIFF
--- a/inform7/extensions/standard_rules/Sections/Actions.w
+++ b/inform7/extensions/standard_rules/Sections/Actions.w
@@ -337,7 +337,7 @@ Putting it on is an action applying to two things.
 The putting it on action is accessible to Inter as "PutOn".
 
 The specification of the putting it on action is "By this action, an actor puts
-something he is holding on top of a supporter: for instance, putting an apple
+something they are holding on top of a supporter: for instance, putting an apple
 on a table."
 
 @ Check.
@@ -412,7 +412,7 @@ Inserting it into is an action applying to two things.
 The inserting it into action is accessible to Inter as "Insert".
 
 The specification of the inserting it into action is "By this action, an actor puts
-something he is holding into a container: for instance, putting a coin into a
+something they are holding into a container: for instance, putting a coin into a
 collection box."
 
 @ Check.
@@ -1237,8 +1237,8 @@ model does not have a concept of things being under other things, so this
 action is only minimally provided by the Standard Rules, but it exists here
 for traditional reasons (and because, after all, LOOK UNDER TABLE is the
 sort of command which ought to be recognised even if it does nothing useful).
-The action ordinarily either tells the player he finds nothing of interest,
-or reports that somebody else has looked under something.
+The action ordinarily either tells the player that they find nothing of
+interest, or reports that somebody else has looked under something.
 
 The usual way to make this action do something useful is to write a rule
 like 'Instead of looking under the cabinet for the first time: now the
@@ -1972,11 +1972,11 @@ Waking is an action applying to one thing.
 The waking action is accessible to Inter as "WakeOther".
 
 The specification of the waking action is "This is the act of jostling
-a sleeping person to wake him or her up, and it finds its way into the
-Standard Rules only for historical reasons. Inform does not by default
-provide any model for people being asleep or awake, so this action does
-not do anything in the standard implementation: instead, it is always
-stopped by the block waking rule."
+a sleeping person to wake them up, and it finds its way into the Standard
+Rules only for historical reasons. Inform does not by default provide
+any model for people being asleep or awake, so this action doesnot do
+anything in the standard implementation: instead, it is always stopped by
+the block waking rule."
 
 @ Check.
 
@@ -2046,7 +2046,7 @@ The attacking action is accessible to Inter as "Attack".
 The specification of the attacking action is "Violence is seldom the answer,
 and attempts to attack another person are normally blocked as being unrealistic
 or not seriously meant. (I might find a shop assistant annoying, but IF is
-not Grand Theft Auto, and responding by killing him is not really one of
+not Grand Theft Auto, and responding by killing them is not really one of
 my options.) So the Standard Rules simply block attempts to fight people,
 but the action exists for rules to make exceptions."
 

--- a/inform7/extensions/standard_rules/Sections/Physical World Model.w
+++ b/inform7/extensions/standard_rules/Sections/Physical World Model.w
@@ -88,8 +88,8 @@ beneath a cloak, but not to a key placed at the back of a shelf by somebody
 long gone.
 
 =
-The verb to conceal (he conceals, they conceal, he concealed, it is concealed,
-he is concealing) means the concealment relation.
+The verb to conceal (she conceals, they conceal, he concealed, it is concealed,
+it is concealing) means the concealment relation.
 Definition: Something is concealed rather than unconcealed if the holder of it conceals it.
 
 @ If a supporter or container has something on/in it, but all the contents are concealed or
@@ -344,7 +344,7 @@ like an assertion much like others above ("A thing is usually inedible", for
 instance) -- but in fact it is an "implication": it says that an object having
 one property also probably has another. The Standard Rules make only very
 sparing use of implications. They can trip up the user (who may quite
-reasonably say that it is up to him what properties something has): but they
+reasonably say that it is up to them what properties something has): but they
 are invaluable if they cause Inform to make deductions which any human reader
 would always make without thought.
 
@@ -520,7 +520,7 @@ it's all a matter of which side you look at it from. What we call the
 the green door", depends entirely on which side of the green door we
 stand. The awkward truth is that these expressions are undefined unless
 the player is in one of the (possibly) two rooms in which the green
-door is present; and then they are defined relative to him.
+door is present; and then they are defined relative to the player.
 
 The leading-through relation is built in to Inform. This has to be stored
 in the property "door_to", but we don't want to give authors direct access
@@ -937,7 +937,7 @@ an exception, but that's why the rule is only "usually".)
 If all vehicles were wheeled, there would be a case for a rule such as
 "A vehicle is usually pushable between rooms." But this seems more likely
 to trip up the designer with a surprise discovery in beta-testing than to
-help him achieve realism. We don't want to be able to push hot-air balloons,
+help them achieve realism. We don't want to be able to push hot-air balloons,
 boats or spacecraft between rooms.
 
 =

--- a/inform7/extensions/standard_rules/Sections/Variables and Rulebooks.w
+++ b/inform7/extensions/standard_rules/Sections/Variables and Rulebooks.w
@@ -272,7 +272,7 @@ way or another (though not necessarily in "death").
 Briefly, the startup phase takes us to the end of the room description
 after the banner is printed. The turn sequence covers a complete turn,
 and runs through from prompting the player for a command to notifying
-him of any change in score which occurred. The shutdown rules then go
+them of any change in score which occurred. The shutdown rules then go
 from printing the obituary text, through final score, to the question
 about quitting or restarting.
 
@@ -654,8 +654,8 @@ and act accordingly if so.
 
 (-i) Gives the "handled" property to everything carried or worn by the player.
 (-ii) Changes the current player's holdall in use, if necessary. (That's to
-say: if the player has dropped his previous player's holdall, we try to find a
-new one to use from his remaining possessions.)
+say: if the player has dropped their previous player's holdall, we try to find a
+new one to use from their remaining possessions.)
 
 (k) The "notify score changes rule" tells the player if the score has changed
 during the turn, or rather, since the last time either this rule or the startup
@@ -973,8 +973,8 @@ The work out details of specific action rule is defined by Inter as
 
 @h Player's action awareness.
 This rulebook decides whether or not an action by somebody should be routinely
-reported to the player: is he aware of it having taken place? If the rulebook
-positively succeeds then he is, and otherwise not.
+reported to the player: are they aware of it having taken place? If the rulebook
+positively succeeds then they are, and otherwise not.
 
 =
 A player's action awareness rule
@@ -993,7 +993,7 @@ A player's action awareness rule
 @h Accessibility.
 The "accessibility" rulebook is not very visible to users: it's another
 behind-the-scenes rulebook for managing the decision as to whether the actor
-can touch any items which the intended action requires him to be able to
+can touch any items which the intended action requires them to be able to
 reach.
 
 In its default configuration, it contains only the "access through barriers"


### PR DESCRIPTION
This leaves the `the player aware of his own actions rule` in Variables and Rulebooks.w untouched on the grounds that that changing it could break code. That said, in practice no one messes with the awareness rules, and in my opinion it would be worth changing "his" to "their" but I'll leave the potentially code-breaking call to you.