### PR TITLE
A few CSS overrides to make the documentation useful on small screens, such as phones

### DIFF
--- a/docs/docs-assets/Navigation.css
+++ b/docs/docs-assets/Navigation.css
@@ -149,3 +149,38 @@ nav[role="navigation"] h1 {
 		display: none;
 	}
 }
+
+/* A few overrides to make the documentation useful on small screens, such as phones */
+
+@media (max-width: 700px) {
+    /* tighten up the margins and allow putting the nav menu at the end of the page */
+    body {
+        display: flex;
+        flex-direction: column;
+        margin: 5px 0 !important;
+    }
+    /* nav menu at the end of the page, not a floating sidebar over the top of the content */
+    nav[role="navigation"] {
+        position: static;
+        overflow: auto;
+        order: 2;
+    }
+    /* full-width main without big indent to leave space for the nav menu */
+    main {
+        width: 100%;
+        margin: 0;
+        padding-left: 5px;
+        padding-right: 5px;
+        box-sizing: border-box;
+    }
+    /* constrain to screen width on narrow screens, rather than explicitly overflowing */
+    main p.commentary, main p.purpose {
+        width: auto;
+    }
+    div.breadcrumbs {
+        position: static;
+    }
+    div.contentspage .chapterlist .sectionlist li {
+        padding-left: 1.5em;
+    }
+}


### PR DESCRIPTION
The woven Inform7 docs aren't all that useful on a small screen like a phone, because the layout rather assumes that the screen is wide and so can happily have two columns, with the navigation menu on the left. This is a very (very) basic set of overrides for narrower screens, which put the nav menu at the end (rather than on top of the main content) and so make the docs readable fine on a phone. There are doubtless other problems here (in particular, ASCII art diagrams and tables and the like are decidedly imperfect still) but these small tweaks are probably a material improvement on small screens over what's there currently, even if they don't solve everything.

![image](https://github.com/ganelson/inform/assets/4356350/8485f22c-8f0b-474e-af57-25fd56fc6a89)
