### PR TITLE
Use unsigned constants in reading words from C memory model

### DIFF
--- a/inform7/Internal/Miscellany/inform7_clib.c
+++ b/inform7/Internal/Miscellany/inform7_clib.c
@@ -155,7 +155,7 @@ i7word_t i7_read_sword(i7process_t *proc, i7word_t array_address, i7word_t array
 		i7_fatal_exit(proc);
 	}
 	return             (i7word_t) data[byte_position + 1]  +
-	            0x100*((i7word_t) data[byte_position + 0]);
+	            0x100U*((i7word_t) data[byte_position + 0]);
 }
 
 i7word_t i7_read_word(i7process_t *proc, i7word_t array_address, i7word_t array_index) {
@@ -166,9 +166,9 @@ i7word_t i7_read_word(i7process_t *proc, i7word_t array_address, i7word_t array_
 		i7_fatal_exit(proc);
 	}
 	return             (i7word_t) data[byte_position + 3]  +
-	            0x100*((i7word_t) data[byte_position + 2]) +
-		      0x10000*((i7word_t) data[byte_position + 1]) +
-		    0x1000000*((i7word_t) data[byte_position + 0]);
+	            0x100U*((i7word_t) data[byte_position + 2]) +
+		      0x10000U*((i7word_t) data[byte_position + 1]) +
+		    0x1000000U*((i7word_t) data[byte_position + 0]);
 }
 void i7_write_byte(i7process_t *proc, i7word_t address, i7byte_t new_val) {
 	proc->state.memory[address] = new_val;

--- a/inter/final-module/Chapter 5/C Memory Model.w
+++ b/inter/final-module/Chapter 5/C Memory Model.w
@@ -304,7 +304,7 @@ i7word_t i7_read_sword(i7process_t *proc, i7word_t array_address, i7word_t array
 		i7_fatal_exit(proc);
 	}
 	return             (i7word_t) data[byte_position + 1]  +
-	            0x100*((i7word_t) data[byte_position + 0]);
+	            0x100U*((i7word_t) data[byte_position + 0]);
 }
 
 i7word_t i7_read_word(i7process_t *proc, i7word_t array_address, i7word_t array_index) {
@@ -315,9 +315,9 @@ i7word_t i7_read_word(i7process_t *proc, i7word_t array_address, i7word_t array_
 		i7_fatal_exit(proc);
 	}
 	return             (i7word_t) data[byte_position + 3]  +
-	            0x100*((i7word_t) data[byte_position + 2]) +
-		      0x10000*((i7word_t) data[byte_position + 1]) +
-		    0x1000000*((i7word_t) data[byte_position + 0]);
+	            0x100U*((i7word_t) data[byte_position + 2]) +
+		      0x10000U*((i7word_t) data[byte_position + 1]) +
+		    0x1000000U*((i7word_t) data[byte_position + 0]);
 }
 =
 


### PR DESCRIPTION
When compiling with clang at O1 and above, I've had crashes in the Eg<n>-C examples. This turns out to be caused by the i7_read_word() function returning an incorrect value. The cause of this is related to signed / unsigned conversion in the function. Changing the 0x100... constants to unsigned integers fixes this. I'm not entirely sure I believe clang's optimizer is entitled to break the code as it was, but I can believe that the multiplication when using signed values everywhere leads to technically undefined behaviour.