### PR TITLE
Allow Unicode control characters to be printed with "say" under Glulx…

### DIFF
--- a/inform7/Internal/Inter/Architecture32Kit/Sections/Veneer.i6t
+++ b/inform7/Internal/Inter/Architecture32Kit/Sections/Veneer.i6t
@@ -7,6 +7,11 @@ which uses them to replace its default "veneer" functions. If we're compiling
 to something other than Inform 6, though, they are just strangely-named functions,
 and do no harm.
 
+The replacement of RT__ChPrintC is necessary to allow Unicode control characters (including tab)
+typed at the command line to be printed into internal buffers in Inform 7.
+The standard Inform 6 veneer routine will put an error message into the buffer instead, which is
+a highly undesirable and confusing error condition.
+
 =
 [ Unsigned__Compare x y;
 	@jleu x y ?lesseq;
@@ -26,4 +31,8 @@ and do no harm.
 [ RT__ChLDB x y;
 	@aloadb x y sp;
 	@return sp;
+];
+
+[ RT__ChPrintC c;
+	@streamunichar c;
 ];


### PR DESCRIPTION
… by overriding I6 veneer code when compiling I7 for Glulx.

This provides a more complete fix for the problems discussed here.  Now that Inform uses Unicode input, this is correct for conformance with the Glulx/Glk specification.  It makes it possible to handle control characters in I7 code.

https://intfiction.org/t/debugging-the-player-typed-a-tab-problems-in-inform-7-for-glulx/66852/10

This is a more complete fix and renders the other fix unnecessary.  (Although the other fix WILL speed things up and simplify code paths.  I am considering developing it into a more general rework to eliminate a bunch of other snippet-related bugs by converting snippets to texts uniformly, so that snippets don't need as much special-case code.)