### PR TITLE
ensuring that nothing can be both off-stage and not offstage

### DIFF
--- a/inform7/extensions/standard_rules/Sections/Physical World Model.w
+++ b/inform7/extensions/standard_rules/Sections/Physical World Model.w
@@ -148,7 +148,7 @@ answer would be no.)
 =
 Definition: Something is on-stage rather than off-stage if I6 routine "OnStage"
 	makes it so (it is indirectly in one of the rooms).
-Definition: Something is offstage if it is off-stage.
+Definition: An object is offstage if it is not on-stage.
 
 Definition: a scene is happening if I6 condition "scene_status-->(*1-1)==1"
 	says so (it is currently taking place).


### PR DESCRIPTION
The docs more or less indicate that testing the on-stage-ness of non-thing objects is undefined behavior. But you *can* ask whether a room is on-stage or off-stage and the result is off-stage. But the result of asking whether a room is offstage is that it is *not* offstage. So this trivial patch for a trivial problem makes offstage consistent with off-stage.