### PR TITLE
Whitespace homogenizer

### DIFF
--- a/inform7/Internal/Inter/Architecture16Kit/Sections/Input Output.i6t
+++ b/inform7/Internal/Inter/Architecture16Kit/Sections/Input Output.i6t
@@ -141,7 +141,7 @@ to document all of that.
 [ VM_ReadKeyboard a_buffer a_table ix;
 	read a_buffer a_table;
 	for ( ix = 2 : ix <= (a_buffer->1) + 1 : ix++ )
-		if ((a_buffer->ix) == 9 or 160) a_buffer->ix = 32;
+		if (((a_buffer->ix) < 32) || ((a_buffer->ix) == 160)) a_buffer->ix = 32;
 ];
 
 @h Buffer Functions.

--- a/inform7/Internal/Inter/Architecture16Kit/Sections/Input Output.i6t
+++ b/inform7/Internal/Inter/Architecture16Kit/Sections/Input Output.i6t
@@ -138,8 +138,10 @@ to document all of that.
 ];
 [ VM_KeyDelay_Interrupt; rtrue; ];
 
-[ VM_ReadKeyboard a_buffer a_table;
+[ VM_ReadKeyboard a_buffer a_table ix;
 	read a_buffer a_table;
+	for ( ix = 2 : ix <= (a_buffer->1) + 1 : ix++ )
+		if ((a_buffer->ix) == 9 or 160) a_buffer->ix = 32;
 ];
 
 @h Buffer Functions.

--- a/inform7/Internal/Inter/Architecture32Kit/Sections/Input Output.i6t
+++ b/inform7/Internal/Inter/Architecture32Kit/Sections/Input Output.i6t
@@ -278,7 +278,7 @@ to document all of that.
     return key;
 ];
 
-Array UnicodeWhitespace --> 24 9 10 11 12 13 133 160 5760 8192 8193 8194 8195 8196 8197 8198 8199 8200 8201 8202 8232 8233 8239 8287 12288;
+Array UnicodeWhitespace --> 8 133 160 5760 8232 8233 8239 8287 12288;
 
 [ VM_ReadKeyboard  a_buffer a_table done ix jy;
     if (gg_commandstr ~= 0 && gg_command_reading ~= false) {
@@ -321,10 +321,12 @@ Array UnicodeWhitespace --> 24 9 10 11 12 13 133 160 5760 8192 8193 8194 8195 81
         glk_put_char_stream(gg_commandstr, 10); ! newline
     }
   .KPContinue;
-    for ( ix = 1 : ix <= (a_buffer-->0) : ix++ ) {
-      for ( jy = 1 : jy <= (UnicodeWhitespace-->0) : jy++ )
-        if ((a_buffer-->ix) == (UnicodeWhitespace-->jy)) a_buffer-->ix = 32;
-
+    for ( ix = 1 : ix <= (a_buffer-->0) : ix++ )
+      if (((a_buffer-->ix) < 32) || ((((a_buffer-->ix) >= 8192) && ((a_buffer-->ix) <= 8202))))
+        a_buffer-->ix = 32;
+      else
+        for ( jy = 1 : jy <= (UnicodeWhitespace-->0) : jy++ )
+          if ((a_buffer-->ix) == (UnicodeWhitespace-->jy)) a_buffer-->ix = 32;
     VM_Tokenise(a_buffer,a_table);
     ! It's time to close any quote window we've got going.
     if (gg_quotewin) {

--- a/inform7/Internal/Inter/Architecture32Kit/Sections/Input Output.i6t
+++ b/inform7/Internal/Inter/Architecture32Kit/Sections/Input Output.i6t
@@ -327,6 +327,7 @@ Array UnicodeWhitespace --> 8 133 160 5760 8232 8233 8239 8287 12288;
       else
         for ( jy = 1 : jy <= (UnicodeWhitespace-->0) : jy++ )
           if ((a_buffer-->ix) == (UnicodeWhitespace-->jy)) a_buffer-->ix = 32;
+	  else if ((a_buffer-->ix) < (UnicodeWhitespace-->jy)) break;
     VM_Tokenise(a_buffer,a_table);
     ! It's time to close any quote window we've got going.
     if (gg_quotewin) {

--- a/inform7/Internal/Inter/Architecture32Kit/Sections/Input Output.i6t
+++ b/inform7/Internal/Inter/Architecture32Kit/Sections/Input Output.i6t
@@ -278,7 +278,7 @@ to document all of that.
     return key;
 ];
 
-Array UnicodeWhitespace --> 9 10 11 12 13 133 160 5760 8192 8193 8194 8195 8196 8197 8198 8199 8200 8201 8202 8232 8233 8239 8287 12288;
+Array UnicodeWhitespace --> 24 9 10 11 12 13 133 160 5760 8192 8193 8194 8195 8196 8197 8198 8199 8200 8201 8202 8232 8233 8239 8287 12288;
 
 [ VM_ReadKeyboard  a_buffer a_table done ix jy;
     if (gg_commandstr ~= 0 && gg_command_reading ~= false) {
@@ -321,10 +321,9 @@ Array UnicodeWhitespace --> 9 10 11 12 13 133 160 5760 8192 8193 8194 8195 8196 
         glk_put_char_stream(gg_commandstr, 10); ! newline
     }
   .KPContinue;
-
-    for ( ix = 0 : ix < a_buffer-->0 : ix++ )
-      for ( jy = 0 : jy < UnicodeWhitespace-->0 : jy++ )
-        if (a_buffer-->ix == UnicodeWhitespace-->jy) a_buffer-->ix = 32;
+    for ( ix = 1 : ix <= (a_buffer-->0) : ix++ ) {
+      for ( jy = 1 : jy <= (UnicodeWhitespace-->0) : jy++ )
+        if ((a_buffer-->ix) == (UnicodeWhitespace-->jy)) a_buffer-->ix = 32;
 
     VM_Tokenise(a_buffer,a_table);
     ! It's time to close any quote window we've got going.

--- a/inform7/Internal/Inter/Architecture32Kit/Sections/Input Output.i6t
+++ b/inform7/Internal/Inter/Architecture32Kit/Sections/Input Output.i6t
@@ -278,7 +278,9 @@ to document all of that.
     return key;
 ];
 
-[ VM_ReadKeyboard  a_buffer a_table done ix;
+Array UnicodeWhitespace --> 9 10 11 12 13 133 160 5760 8192 8193 8194 8195 8196 8197 8198 8199 8200 8201 8202 8232 8233 8239 8287 12288;
+
+[ VM_ReadKeyboard  a_buffer a_table done ix jy;
     if (gg_commandstr ~= 0 && gg_command_reading ~= false) {
         done = glk_get_line_stream_uni(gg_commandstr, a_buffer+WORDSIZE,
         	(INPUT_BUFFER_LEN-1)-1);
@@ -319,6 +321,11 @@ to document all of that.
         glk_put_char_stream(gg_commandstr, 10); ! newline
     }
   .KPContinue;
+
+    for ( ix = 0 : ix < a_buffer-->0 : ix++ )
+      for ( jy = 0 : jy < UnicodeWhitespace-->0 : jy++ )
+        if (a_buffer-->ix == UnicodeWhitespace-->jy) a_buffer-->ix = 32;
+
     VM_Tokenise(a_buffer,a_table);
     ! It's time to close any quote window we've got going.
     if (gg_quotewin) {


### PR DESCRIPTION
Addresses [I7-2464](https://inform7.atlassian.net/browse/I7-2464): converts all non-0x20 whitespace in player input to 0x20 prior to tokenization. For the Z-machine, that's the tab character and non breaking space (0xA0). For glulx, it's all the things the unicode standard count as whitespace, decimal 9, 10, 11, 12, 13, 133, 160, 5760, 8192, 8193, 8194, 8195, 8196, 8197, 8198, 8199, 8200, 8201, 8202, 8232, 8233, 8239, 8287, 12288.
