### PR TITLE
Allow for Neptune enums to defined out of numerical order

### DIFF
--- a/inform7/knowledge-module/Chapter 2/Instances.w
+++ b/inform7/knowledge-module/Chapter 2/Instances.w
@@ -351,7 +351,7 @@ void Instances::make_instances_from_Neptune(void) {
 		linked_list *L = KindConstructors::instances(kc);
 		kind_constructor_instance *kci;
 		inter_ti current_val = 0;
-		int first_val = TRUE;
+		inter_ti highest_val = 0;
 		LOOP_OVER_LINKED_LIST(kci, kind_constructor_instance, L) {
 			wording W = Feeds::feed_text(kci->natural_language_name);
 			kind *K = Kinds::base_construction(kc);
@@ -359,26 +359,18 @@ void Instances::make_instances_from_Neptune(void) {
 			Assert::true(prop, CERTAIN_CE);
 			instance *I = Instances::latest();
 			if (kci->value_specified) {
-				if ((current_val >= (inter_ti) kci->value) && (first_val == FALSE)) {
-					Problems::quote_object(1, I);
-					Problems::quote_kind(2, K);
-					StandardProblems::handmade_problem(Task::syntax_tree(), _p_(Untestable));
-					Problems::issue_problem_segment(
-						"A kit defined an instance %1 of a kind called %2, but this "
-						"has a numerical value which is equal to or greater than that "
-						"of its predecessor. Instances in a kit have to be defined "
-						"in evaluation order.");
-					Problems::issue_problem_end();
-				}
 				current_val = (inter_ti) kci->value;
+				if (current_val > highest_val) {
+					highest_val = current_val;
+				}
 			}
 			else {
-				current_val++;
+				highest_val++;
+				current_val = highest_val;
 			}
 			RTKindConstructors::set_explicit_runtime_instance_value(K, I, current_val);
 			RTInstances::set_translation(I, kci->identifier);
 			// LOG("From kit: %W = %S = %d -> $O\n", W, kci->identifier, current_val, I);
-			first_val = FALSE;
 		}
 	}
 }

--- a/inform7/knowledge-module/Chapter 2/Instances.w
+++ b/inform7/knowledge-module/Chapter 2/Instances.w
@@ -352,6 +352,16 @@ void Instances::make_instances_from_Neptune(void) {
 		kind_constructor_instance *kci;
 		inter_ti current_val = 0;
 		inter_ti highest_val = 0;
+		// First loop to determine the highest specified value
+		LOOP_OVER_LINKED_LIST(kci, kind_constructor_instance, L) {
+			if (kci->value_specified) {
+				current_val = (inter_ti) kci->value;
+				if (current_val > highest_val) {
+					highest_val = current_val;
+				}
+			}
+		}
+		// Then loop to add the values and work out the non-specified ones
 		LOOP_OVER_LINKED_LIST(kci, kind_constructor_instance, L) {
 			wording W = Feeds::feed_text(kci->natural_language_name);
 			kind *K = Kinds::base_construction(kc);
@@ -360,9 +370,6 @@ void Instances::make_instances_from_Neptune(void) {
 			instance *I = Instances::latest();
 			if (kci->value_specified) {
 				current_val = (inter_ti) kci->value;
-				if (current_val > highest_val) {
-					highest_val = current_val;
-				}
 			}
 			else {
 				highest_val++;


### PR DESCRIPTION
It was very easy to allow for Neptune enums to be defined in a non-numerical order. This could be important when matching other APIs. There is still support for non-numbered entries by ensuring that they come after all specified ones.

I should add a test though...