### PR TITLE
Make undescribed never in scope (except for player)

### DIFF
--- a/inform7/Internal/Inter/CommandParserKit/Sections/Parser.i6t
+++ b/inform7/Internal/Inter/CommandParserKit/Sections/Parser.i6t
@@ -3619,6 +3619,8 @@ mechanism.
 =
 [ DoScopeAction item;
 
+    if (item has concealed) return;
+
     #Ifdef DEBUG;
     if (parser_trace >= 6)
         print "[DSA on ", (the) item, " with reason = ", scope_reason,

--- a/inform7/Internal/Inter/CommandParserKit/Sections/Parser.i6t
+++ b/inform7/Internal/Inter/CommandParserKit/Sections/Parser.i6t
@@ -3619,7 +3619,7 @@ mechanism.
 =
 [ DoScopeAction item;
 
-    if (item has concealed) return;
+    if ((item has concealed) && (item ~= player)) return;
 
     #Ifdef DEBUG;
     if (parser_trace >= 6)


### PR DESCRIPTION
This adds one line at the beginning of DoScopeAction in Parser.i6t:

```
if ((item has concealed) && (item ~= player)) return;
```

Currently, if the author hasn't also made it privately-named, a player might accidentally refer to an undescribed thing, and the parser might automatically choose an undescribed thing when the player didn't specify a noun. I don't think either of these outcomes are expected or desired by anyone who made something undescribed. 

To no great surprise, this affects the Undescribed test case. It also causes a trivial output difference in InferredRegionKind. Their output would need re-blessing.