### PR TITLE
Don't explicitly transfer languages when integrating.

### DIFF
--- a/scripts/inform.mkscript
+++ b/scripts/inform.mkscript
@@ -620,7 +620,6 @@ forceintegration: \
 		forcetransferindext \
 		forcetransferkits \
 		forcetransferextensions \
-		forcetransferlanguages \
 		forcetransferplanguages \
 		forcetransferimages \
 		forcetransferotherinternals \
@@ -730,19 +729,6 @@ forcetransferextensions:
 	{transfer-extensions}
 
 # -----------------------------------------------------------------------------
-# Copying language bundles into the app
-
-{define: transfer-languages}
-	mkdir -p "$(INTERNAL)/Languages"
-	cp -R -f $(INFORM7WEB)/Internal/Languages $(INTERNAL)/Languages/..
-	rm -f $(INTERNAL)/Languages/*/about.txt
-{end-define}
-
-.PHONY: forcetransferlanguages
-forcetransferlanguages:
-	{transfer-languages}
-
-# -----------------------------------------------------------------------------
 # Copying programming language defns into the app
 
 {define: transfer-planguages}
@@ -817,7 +803,6 @@ $(INTERNALEXEMPLUMFROM):
 
 $(INTERNALEXEMPLUM): \
 		$(INFORM7WEB)/Internal/Extensions/Graham\ Nelson/[A-Za-z]* \
-		$(INFORM7WEB)/Internal/Languages/*/*.* \
 		$(INFORM7WEB)/Internal/Templates/*/*.* \
 		$(INFORM7WEB)/Internal/HTML/[A-Za-z]*.* \
 		$(INFORM7WEB)/Internal/Delia/[A-Za-z]*.* \
@@ -831,7 +816,6 @@ $(INTERNALEXEMPLUM): \
 		$(INFORM7WEB)/Internal/Miscellany/[A-Za-z]*.*
 	touch $(INTERNALEXEMPLUMFROM)
 	{transfer-extensions}
-	{transfer-languages}
 	{transfer-planguages}
 	{transfer-templates}
 	{transfer-other-internals}


### PR DESCRIPTION
Languages are extensions now, so the existing extension transfer rules will do the job.

Fixes I7-2517.