### PR TITLE
More cumulative Glk updates

### DIFF
--- a/inform7/Internal/Extensions/Graham Nelson/Basic Inform.i7xd/Materials/Inter/Architecture32Kit/RTPs/EventHandledWhileInactive.md
+++ b/inform7/Internal/Extensions/Graham Nelson/Basic Inform.i7xd/Materials/Inter/Architecture32Kit/RTPs/EventHandledWhileInactive.md
@@ -1,0 +1,3 @@
+# Cannot handle new event while not handling events
+
+The `handle (event) instead` phrase was used, but Glk events aren't being handled at all right now. This phrase can only be used in `glk event handling` rules, or in rulebooks that are themselves run in `glk event handling` rules.

--- a/inform7/Internal/Extensions/Graham Nelson/Basic Inform.i7xd/Materials/Inter/Architecture32Kit/RTPs/EventHandledWhileInactive.md
+++ b/inform7/Internal/Extensions/Graham Nelson/Basic Inform.i7xd/Materials/Inter/Architecture32Kit/RTPs/EventHandledWhileInactive.md
@@ -1,3 +1,3 @@
 # Cannot handle new event while not handling events
 
-The `handle (event) instead` phrase was used, but Glk events aren't being handled at all right now. This phrase can only be used in `glk event handling` rules, or in rulebooks that are themselves run in `glk event handling` rules.
+The `handle (event)` phrase was used, but Glk events aren't being handled at all right now. This phrase can only be used in `glk event handling` rules, or in rulebooks that are themselves run in `glk event handling` rules.

--- a/inform7/Internal/Extensions/Graham Nelson/Basic Inform.i7xd/Materials/Inter/Architecture32Kit/RTPs/EventInvalidMouseCoords.md
+++ b/inform7/Internal/Extensions/Graham Nelson/Basic Inform.i7xd/Materials/Inter/Architecture32Kit/RTPs/EventInvalidMouseCoords.md
@@ -1,0 +1,3 @@
+# Glk mouse event created with invalid coordinates
+
+Glk mouse events must be created with valid coordinates. Note in particular that graphics windows are 0-based (meaning the top left is (0, 0)), while grid windows are 1-based (meaning the top left is (1, 1)).

--- a/inform7/Internal/Extensions/Graham Nelson/Basic Inform.i7xd/Materials/Inter/Architecture32Kit/Sections/Glk.i6t
+++ b/inform7/Internal/Extensions/Graham Nelson/Basic Inform.i7xd/Materials/Inter/Architecture32Kit/Sections/Glk.i6t
@@ -90,8 +90,10 @@ Global current_glk_object_reference = 0;
 	statuswin_cursize = 0;
 	gg_foregroundchan = 0;
 	gg_backgroundchan = 0;
+#Ifdef COMMAND_STREAM;
 	gg_commandstr = 0;
 	gg_command_reading = false;
+#Endif;
 	rfalse;
 ];
 
@@ -134,6 +136,9 @@ Global current_glk_object_reference = 0;
 			gg_savestr = current_glk_object_reference;
 		GG_SCRIPTSTR_ROCK:
 			gg_scriptstr = current_glk_object_reference;
+	}
+#Ifdef COMMAND_STREAM;
+	switch (current_glk_object_rock) {
 		GG_COMMANDWSTR_ROCK:
 			gg_commandstr = current_glk_object_reference;
 			gg_command_reading = false;
@@ -141,6 +146,7 @@ Global current_glk_object_reference = 0;
 			gg_commandstr = current_glk_object_reference;
 			gg_command_reading = true;
 	}
+#Endif;
 	rfalse;
 ];
 

--- a/inform7/Internal/Extensions/Graham Nelson/Basic Inform.i7xd/Materials/Inter/Architecture32Kit/Sections/Glk.i6t
+++ b/inform7/Internal/Extensions/Graham Nelson/Basic Inform.i7xd/Materials/Inter/Architecture32Kit/Sections/Glk.i6t
@@ -373,8 +373,12 @@ event BVs.
 			}
 			! Fix the coordinates of grid window mouse events
 			if (win_obj.glk_window_type == wintype_TextGrid) {
-				val1 = val1--;
-				val2 = val2--;
+				val1--;
+				val2--;
+			}
+			if (val1 < 0 || val2 < 0) {
+				IssueRTP("EventInvalidMouseCoords", "GLK_EVENT_TY_New: Glk mouse event created with invalid coordinates.", Architecture32KitRTPs);
+				return ev;
 			}
 	}
 	ev-->GLK_EVENT_TYPE_SF = evtype;
@@ -400,17 +404,19 @@ event BVs.
 	return nothing;
 ];
 
-[ GLK_EVENT_TY_Value1 ev;
-	switch (ev-->GLK_EVENT_TYPE_SF) {
-		evtype_CharInput:
-			return MapGlkKeyCodeToUnicode(ev-->GLK_EVENT_VALUE1_SF);
-		evtype_MouseInput:
-			if ((ev-->GLK_EVENT_WINDOW_SF).glk_window_type == wintype_TextGrid) {
-				return ev-->GLK_EVENT_VALUE1_SF + 1;
-			}
-			return ev-->GLK_EVENT_VALUE1_SF;
-		evtype_Hyperlink:
-			return ev-->GLK_EVENT_VALUE1_SF;
+[ GLK_EVENT_TY_Value1 ev evtype;
+	if (evtype == ev-->GLK_EVENT_TYPE_SF) {
+		switch (evtype) {
+			evtype_CharInput:
+				return MapGlkKeyCodeToUnicode(ev-->GLK_EVENT_VALUE1_SF);
+			evtype_MouseInput:
+				if ((ev-->GLK_EVENT_WINDOW_SF).glk_window_type == wintype_TextGrid) {
+					return ev-->GLK_EVENT_VALUE1_SF + 1;
+				}
+				return ev-->GLK_EVENT_VALUE1_SF;
+			evtype_Hyperlink:
+				return ev-->GLK_EVENT_VALUE1_SF;
+		}
 	}
 	IssueRTP("EventWrongType", "GLK_EVENT_TY_Value1: Glk event phrase called for wrong event type.", Architecture32KitRTPs);
 	return 0;

--- a/inform7/Internal/Extensions/Graham Nelson/Basic Inform.i7xd/Materials/Inter/Architecture32Kit/Sections/Glk.i6t
+++ b/inform7/Internal/Extensions/Graham Nelson/Basic Inform.i7xd/Materials/Inter/Architecture32Kit/Sections/Glk.i6t
@@ -494,16 +494,26 @@ the event struct.
 	event_struct-->3 = ev-->GLK_EVENT_VALUE2_SF;
 ];
 
-@ |GLK_EVENT_TY_Process| applies a glk event onto the current glk event, and
+@ |GLK_EVENT_TY_Handle_Instead| applies a glk event onto the current glk event, and
 tells glk_select to re-run the glk event handling rules. It also ensures that
 if there are any pending keyboard input requests they will be cancelled if the
 new event is a keyboard event.
 
 =
 Array current_glk_event --> [ BLK_BVBITMAP_SBONLY; GLK_EVENT_TY; 0; 0; 0; 0; 0; 0; 0; ];
-Global glk_event_replaced;
 
-[ GLK_EVENT_TY_Process ev evtype win_obj;
+Constant GLK_EVENT_HANDLING_INACTIVE   0;
+Constant GLK_EVENT_HANDLING_ACTIVE     1;
+Constant GLK_EVENT_HANDLING_REHANDLING 2;
+Global glk_event_handling_status = GLK_EVENT_HANDLING_INACTIVE;
+
+[ GLK_EVENT_TY_Handle_Instead ev evtype win_obj;
+	if (glk_event_handling_status == GLK_EVENT_HANDLING_INACTIVE) {
+		IssueRTP("EventHandledWhileInactive", "Cannot handle new event while not handling events.", Architecture32KitRTPs);
+		RulebookSucceeds();
+		rtrue;
+	}
+
 	evtype = ev-->GLK_EVENT_TYPE_SF;
 	win_obj = ev-->GLK_EVENT_WINDOW_SF;
 
@@ -534,7 +544,7 @@ Global glk_event_replaced;
 	current_glk_event-->GLK_EVENT_VALUE2_SF = ev-->GLK_EVENT_VALUE2_SF;
 
 	RulebookSucceeds();
-	glk_event_replaced = 1;
+	glk_event_handling_status = GLK_EVENT_HANDLING_REHANDLING;
 ];
 
 @ To handle events we intercept the |glk_select| function. This allows us to handle
@@ -552,9 +562,10 @@ events early and consistently.
 	@push debug_rules; @push say__p; @push say__pc;
 	debug_rules = false; ClearParagraphing(1);
 	do {
-		glk_event_replaced = 0;
+		glk_event_handling_status = GLK_EVENT_HANDLING_ACTIVE;
 		FollowRulebook(GLK_EVENT_HANDLING_RB, current_glk_event-->GLK_EVENT_TYPE_SF, true);
-	} until (glk_event_replaced == 0);
+	} until (glk_event_handling_status == GLK_EVENT_HANDLING_ACTIVE);
+	glk_event_handling_status = GLK_EVENT_HANDLING_INACTIVE;
 	@pull say__pc; @pull say__p; @pull debug_rules;
 
 	GLK_EVENT_TY_To_Struct(current_glk_event, event_struct);

--- a/inform7/Internal/Extensions/Graham Nelson/Basic Inform.i7xd/Materials/Inter/Architecture32Kit/Sections/Input Output.i6t
+++ b/inform7/Internal/Extensions/Graham Nelson/Basic Inform.i7xd/Materials/Inter/Architecture32Kit/Sections/Input Output.i6t
@@ -12,8 +12,10 @@ Constant GG_STATUSWIN_ROCK      202;
 Constant GG_QUOTEWIN_ROCK       203;
 Constant GG_SAVESTR_ROCK        301;
 Constant GG_SCRIPTSTR_ROCK      302;
+#Ifdef COMMAND_STREAM;
 Constant GG_COMMANDWSTR_ROCK    303;
 Constant GG_COMMANDRSTR_ROCK    304;
+#Endif;
 Constant GG_SCRIPTFREF_ROCK     401;
 Constant GG_FOREGROUNDCHAN_ROCK 410;
 Constant GG_BACKGROUNDCHAN_ROCK 411;
@@ -137,8 +139,10 @@ Global gg_mainwin = 0;
 Global gg_statuswin = 0;
 Global gg_quotewin = 0;
 Global gg_savestr = 0;
+#Ifdef COMMAND_STREAM;
 Global gg_commandstr = 0;
 Global gg_command_reading = 0;      ! true if gg_commandstr is being replayed
+#Endif;
 Global gg_foregroundchan = 0;
 Global gg_backgroundchan = 0;
 
@@ -180,6 +184,7 @@ to document all of that.
 [ VM_KeyChar win done res ix jx ch;
     jx = ch; ! squash compiler warnings
     if (win == 0) win = gg_mainwin;
+#Ifdef COMMAND_STREAM;
     if (gg_commandstr ~= 0 && gg_command_reading ~= false) {
         done = glk_get_line_stream(gg_commandstr, gg_arguments, 31);
         if (done == 0) {
@@ -210,6 +215,7 @@ to document all of that.
        		jump KCPContinue;
         }
     }
+#Endif;
     done = false;
     glk_request_char_event(win);
     while (~~done) {
@@ -222,6 +228,7 @@ to document all of that.
             }
         }
     }
+#Ifdef COMMAND_STREAM;
     if (gg_commandstr ~= 0 && gg_command_reading == false) {
         if (res < 32 || res >= 256 || (res == '\' or ' ')) {
             glk_put_char_stream(gg_commandstr, '\');
@@ -244,6 +251,7 @@ to document all of that.
         glk_put_char_stream(gg_commandstr, 10); ! newline
     }
   .KCPContinue;
+#Endif;
 	return MapGlkKeyCodeToUnicode(res);
 ];
 
@@ -266,6 +274,7 @@ Array UnicodeWhitespace --> 133 160 5760 8232 8233 8239 8287 12288;
 Constant UnicodeWhitespaceLen = 8;
 
 [ VM_ReadKeyboard  a_buffer a_table done ix chr;
+#Ifdef COMMAND_STREAM;
     if (gg_commandstr ~= 0 && gg_command_reading ~= false) {
         done = glk_get_line_stream_uni(gg_commandstr, a_buffer+WORDSIZE,
         	(INPUT_BUFFER_LEN-1)-1);
@@ -284,6 +293,7 @@ Constant UnicodeWhitespaceLen = 8;
             jump KPContinue;
         }
     }
+#Endif;
     done = false;
     glk_request_line_event_uni(gg_mainwin, a_buffer+WORDSIZE, INPUT_BUFFER_LEN-1, 0);
     while (~~done) {
@@ -303,11 +313,13 @@ Constant UnicodeWhitespaceLen = 8;
 		glk_set_style(style_Normal);
 		glk_put_char(10); ! newline
 	}
+#Ifdef COMMAND_STREAM;
     if (gg_commandstr ~= 0 && gg_command_reading == false) {
         glk_put_buffer_stream(gg_commandstr, a_buffer+WORDSIZE, a_buffer-->0);
         glk_put_char_stream(gg_commandstr, 10); ! newline
     }
   .KPContinue;
+#Endif;
 
     for ( ix = 1 : ix <= (a_buffer-->0) : ix++ ) {
       chr = a_buffer-->ix;

--- a/inform7/Internal/Extensions/Graham Nelson/Basic Inform.i7xd/Source/Basic Inform.i7x
+++ b/inform7/Internal/Extensions/Graham Nelson/Basic Inform.i7xd/Source/Basic Inform.i7x
@@ -1818,19 +1818,19 @@ To decide what glk window is window of (ev - glk event)
 
 To decide what unicode character is the character value of (ev - glk event)
 	(documented at ph_glkeventcharactervalue):
-	(- GLK_EVENT_TY_Value1({ev}) -).
+	(- GLK_EVENT_TY_Value1({ev}, evtype_CharInput) -).
 
 To decide what number is the x coordinate of (ev - glk event):
-	(- GLK_EVENT_TY_Value1({ev}) -).
+	(- GLK_EVENT_TY_Value1({ev}, evtype_MouseInput) -).
 To decide what number is the y coordinate of (ev - glk event):
 	(- GLK_EVENT_TY_Value2({ev}) -).
 To decide what number is the row of (ev - glk event):
 	(- GLK_EVENT_TY_Value2({ev}) -).
-To decide what number is the column of (ev - glk event):
-	(- GLK_EVENT_TY_Value1({ev}) -).
+To decide what number is the column/col of (ev - glk event):
+	(- GLK_EVENT_TY_Value1({ev}, evtype_MouseInput) -).
 
 To decide what number is the hyperlink value of (ev - glk event):
-	(- GLK_EVENT_TY_Value1({ev}) -).
+	(- GLK_EVENT_TY_Value1({ev}, evtype_Hyperlink) -).
 
 To decide what text is the text of (ev - glk event)
 	(documented at ph_glkeventtextvalue):
@@ -1848,8 +1848,8 @@ First glk event handling rule for a glk event type
 	(this is the set glk event processing variables rule):
 	now the event is the current glk event initialiser.
 
-To process (ev - glk event):
-	(- GLK_EVENT_TY_Process({ev}); rtrue; -).
+To handle (ev - glk event):
+	(- GLK_EVENT_TY_Handle_Instead({ev}); rtrue; -).
 
 Glk event handling rule for a screen resize event (this is the redraw the status line rule):
 	redraw the status window;

--- a/inform7/extensions/basic_inform/Sections/Glulx and Glk.w
+++ b/inform7/extensions/basic_inform/Sections/Glulx and Glk.w
@@ -189,8 +189,8 @@ First glk event handling rule for a glk event type
 	(this is the set glk event processing variables rule):
 	now the event is the current glk event initialiser.
 
-To process (ev - glk event):
-	(- GLK_EVENT_TY_Process({ev}); rtrue; -).
+To handle (ev - glk event) instead:
+	(- GLK_EVENT_TY_Handle_Instead({ev}); rtrue; -).
 
 Glk event handling rule for a screen resize event (this is the redraw the status line rule):
 	redraw the status window;

--- a/inform7/extensions/basic_inform/Sections/Glulx and Glk.w
+++ b/inform7/extensions/basic_inform/Sections/Glulx and Glk.w
@@ -156,19 +156,19 @@ To decide what glk window is window of (ev - glk event)
 
 To decide what unicode character is the character value of (ev - glk event)
 	(documented at ph_glkeventcharactervalue):
-	(- GLK_EVENT_TY_Value1({ev}) -).
+	(- GLK_EVENT_TY_Value1({ev}, evtype_CharInput) -).
 
 To decide what number is the x coordinate of (ev - glk event):
-	(- GLK_EVENT_TY_Value1({ev}) -).
+	(- GLK_EVENT_TY_Value1({ev}, evtype_MouseInput) -).
 To decide what number is the y coordinate of (ev - glk event):
 	(- GLK_EVENT_TY_Value2({ev}) -).
 To decide what number is the row of (ev - glk event):
 	(- GLK_EVENT_TY_Value2({ev}) -).
-To decide what number is the column of (ev - glk event):
-	(- GLK_EVENT_TY_Value1({ev}) -).
+To decide what number is the column/col of (ev - glk event):
+	(- GLK_EVENT_TY_Value1({ev}, evtype_MouseInput) -).
 
 To decide what number is the hyperlink value of (ev - glk event):
-	(- GLK_EVENT_TY_Value1({ev}) -).
+	(- GLK_EVENT_TY_Value1({ev}, evtype_Hyperlink) -).
 
 To decide what text is the text of (ev - glk event)
 	(documented at ph_glkeventtextvalue):
@@ -189,7 +189,7 @@ First glk event handling rule for a glk event type
 	(this is the set glk event processing variables rule):
 	now the event is the current glk event initialiser.
 
-To handle (ev - glk event) instead:
+To handle (ev - glk event):
 	(- GLK_EVENT_TY_Handle_Instead({ev}); rtrue; -).
 
 Glk event handling rule for a screen resize event (this is the redraw the status line rule):


### PR DESCRIPTION
- Only include the command stream code if the `COMMAND_STREAM` constant is defined.
    This code is basically vestigial at this point, but we'll leave it in place in case an extension wants to define actions for it again.
- Rename "process (event)" phrase to "handle (event)". (We wanted `handle (event) instead` but it doesn't work)
- Ensure that "handle (event)" is only called at valid times.
- More Glk event type checking