### PR TITLE
Can't stop, won't fail

### DIFF
--- a/inform7/Tests/Test Cases/AfterFail--I.txt
+++ b/inform7/Tests/Test Cases/AfterFail--I.txt
@@ -1,0 +1,17 @@
+
+
+
+
+Welcome
+An Interactive Fiction
+Release 1 / Serial number 160428 / Inform 7 v10.2.0 / D
+
+Lab
+You can see Bob here.
+
+>(Testing.)
+
+>[1] bob, jump
+Someone has jumped!
+
+>Are you sure you want to quit? 

--- a/inform7/Tests/Test Cases/AfterFail.txt
+++ b/inform7/Tests/Test Cases/AfterFail.txt
@@ -1,0 +1,15 @@
+"Jumper Bob"
+
+Lab is a room.
+
+Bob is a person in the Lab.
+
+Persuasion: rule succeeds.
+
+After an actor jumping: rule fails; continue the action.
+
+Unsuccessful attempt by Bob doing anything: say "Bob failed to jump."
+
+Every turn: if we have jumped, say "Someone has jumped!"
+
+Test me with "Bob, jump"

--- a/inform7/extensions/standard_rules/Sections/Actions.w
+++ b/inform7/extensions/standard_rules/Sections/Actions.w
@@ -207,6 +207,18 @@ do this is to write a rule about taking, which covers all possibilities."
 @ Check.
 
 =
+Check an actor removing something from something (this is the can't remove something from itself rule):
+	if the noun is the second noun:
+		if the actor is the player:
+			say "[We] [can't] remove something from itself." (A);
+		stop the action.
+
+Check an actor removing something from something (this is the can't remove something from non-containers rule):
+	if the second noun is not a container:
+		if the actor is the player:
+			say "[regarding the second noun][Those] [can't] contain anything." (A);
+		stop the action.
+
 Check an actor removing something from (this is the can't remove what's not inside rule):
 	if the holder of the noun is not the second noun:
 		if the actor is the player:

--- a/inform7/extensions/standard_rules/Sections/Command Grammar.w
+++ b/inform7/extensions/standard_rules/Sections/Command Grammar.w
@@ -11,9 +11,9 @@ Part Six - Grammar
 Understand "take [things]" as taking.
 Understand "take off [something]" as taking off.
 Understand "take [something] off" as taking off.
-Understand "take [things inside] from [something]" as removing it from.
+Understand "take [things] from [something]" as removing it from.
 Understand "take [something] from [something]" as removing it from. [For better error messages.]
-Understand "take [things inside] off [something]" as removing it from.
+Understand "take [things] off [something]" as removing it from.
 Understand "take [something] off [something]" as removing it from. [For better error messages.]
 Understand "take inventory" as taking inventory.
 Understand the commands "carry" and "hold" as "take".
@@ -23,7 +23,7 @@ Understand "get out/off/down/up" as exiting.
 Understand "get [things]" as taking.
 Understand "get in/into/on/onto [something]" as entering.
 Understand "get off/down [something]" as getting off.
-Understand "get [things inside] from [something]" as removing it from.
+Understand "get [things] from [something]" as removing it from.
 Understand "get [something] from [something]" as removing it from. [For better error messages.]
 
 Understand "pick up [things]" or "pick [things] up" as taking.
@@ -32,7 +32,7 @@ Understand "stand" or "stand up" as exiting.
 Understand "stand on [something]" as entering.
 
 Understand "remove [something preferably held]" as taking off.
-Understand "remove [things inside] from [something]" as removing it from.
+Understand "remove [things] from [something]" as removing it from.
 Understand "remove [something] from [something]" as removing it from. [For better error messages.]
 
 Understand "shed [something preferably held]" as taking off.
@@ -41,17 +41,17 @@ Understand the commands "doff" and "disrobe" as "shed".
 Understand "wear [something preferably held]" as wearing.
 Understand the command "don" as "wear".
 
-Understand "put [other things] in/inside/into [something]" as inserting it into.
-Understand "put [other things] on/onto [something]" as putting it on.
+Understand "put [things] in/inside/into [something]" as inserting it into.
+Understand "put [things] on/onto [something]" as putting it on.
 Understand "put on [something preferably held]" as wearing.
 Understand "put [something preferably held] on" as wearing.
 Understand "put down [things preferably held]" or "put [things preferably held] down" as dropping.
 
-Understand "insert [other things] in/into [something]" as inserting it into.
+Understand "insert [things] in/into [something]" as inserting it into.
 
 Understand "drop [things preferably held]" as dropping.
-Understand "drop [other things] in/into/down [something]" as inserting it into.
-Understand "drop [other things] on/onto [something]" as putting it on.
+Understand "drop [things] in/into/down [something]" as inserting it into.
+Understand "drop [things] on/onto [something]" as putting it on.
 Understand "drop [something preferably held] at/against [something]" as throwing it at.
 Understand the commands "throw" and "discard" as "drop".
 

--- a/inform7/extensions/standard_rules/Sections/Variables and Rulebooks.w
+++ b/inform7/extensions/standard_rules/Sections/Variables and Rulebooks.w
@@ -946,7 +946,8 @@ A specific action-processing rule (this is the carry out stage rule):
 
 A specific action-processing rule (this is the after stage rule):
 	if action in world is true:
-		abide by the after rules.
+		follow the after rules;
+		if rule failed or rule succeeded, rule succeeds;
 
 A specific action-processing rule
 	(this is the investigate player's awareness after action rule):


### PR DESCRIPTION
A low-hanging fruit addressing [I7-2356](https://inform7.atlassian.net/browse/I7-2356). An action that has reached its Carry Out rules should succeed. But if an After rule being run when the actor is an NPC includes `stop the action`, the Unsuccessful Attempt By rules are followed, which should only happen if the action failed. But `if we have <past participle of the action verb>` becomes true which should only become true if the action succeeded (it needs to have been false prior for the action for this to be observed, of course).