### PR TITLE
fix to after stage rule per I7-2356

### DIFF
--- a/inform7/Internal/Extensions/Graham Nelson/Standard Rules.i7xd/Source/Sections/Variables and Rulebooks.w
+++ b/inform7/Internal/Extensions/Graham Nelson/Standard Rules.i7xd/Source/Sections/Variables and Rulebooks.w
@@ -946,7 +946,8 @@ A specific action-processing rule (this is the carry out stage rule):
 
 A specific action-processing rule (this is the after stage rule):
 	if action in world is true:
-		abide by the after rules.
+		follow the after rules;
+		rule succeeds;
 
 A specific action-processing rule
 	(this is the investigate player's awareness after action rule):


### PR DESCRIPTION
A replacement for [PR #174](https://github.com/ganelson/inform/pull/174) in regard to I7-2356. I just noted in a comment there that the docs *are* specific that an action succeeds once its Carry Out rules have been reached, so this behavior seems preferable. 