### PR TITLE
A mapping of `*_PE` in Parser.i6t to parser errors in the Standard Rules

### DIFF
--- a/inform7/Internal/Extensions/Graham Nelson/Standard Rules.i7xd/Materials/Inter/CommandParserKit/Sections/Parser.i6t
+++ b/inform7/Internal/Extensions/Graham Nelson/Standard Rules.i7xd/Materials/Inter/CommandParserKit/Sections/Parser.i6t
@@ -29,34 +29,37 @@ Constant COMMANDPARSERKIT = 1;
 
 @h Parser Error Numbers.
 The traditional ways in which the I6 library's parser, which we adopt here
-more or less intact, can give up on a player's command.
+more or less intact, can give up on a player's command. Comments show the
+corresponding Command Parser Error kind-of-value from the Standard Rules
+and, where applicable, the corresponding Parser Error Internal Rule responses.
+Some of these (labelled "vestigial" below) are no longer in use.
 
 =
-Constant STUCK_PE         = 1;
-Constant UPTO_PE          = 2;
-Constant NUMBER_PE        = 3;
-Constant ANIMA_PE         = 4;
-Constant CANTSEE_PE       = 5;
-Constant TOOLIT_PE        = 6;
-Constant NOTHELD_PE       = 7;
-Constant MULTI_PE         = 8;
-Constant MMULTI_PE        = 9;
-Constant VAGUE_PE         = 10;
-Constant EXCEPT_PE        = 11;
-Constant VERB_PE          = 12;
-Constant SCENERY_PE       = 13;
-Constant ITGONE_PE        = 14;
-Constant JUNKAFTER_PE     = 15;
-Constant TOOFEW_PE        = 16;
-Constant NOTHING_PE       = 17;
-Constant ASKSCOPE_PE      = 18;
-Constant NOTINCONTEXT_PE  = 19;
-Constant BLANKLINE_PE     = 20; ! Not formally a parser error, but used by I7 as if
-Constant ANIMAAGAIN_PE    = 21;
-Constant COMMABEGIN_PE    = 22;
-Constant MISSINGPERSON_PE = 23;
-Constant ANIMALISTEN_PE   = 24;
-Constant TOTALK_PE        = 25;
+Constant STUCK_PE         = 1;   ! didn't understand error (A)
+Constant UPTO_PE          = 2;   ! only understood as far as error (B) / (C)
+Constant NUMBER_PE        = 3;   ! didn't understand that number error (D)
+Constant ANIMA_PE         = 4;   ! can only do that to something animate error (M)
+Constant CANTSEE_PE       = 5;   ! can't see any such thing error (E)
+Constant TOOLIT_PE        = 6;   ! [vestigial] said too little error (F)
+Constant NOTHELD_PE       = 7;   ! [vestigial] aren't holding that error (G)
+Constant MULTI_PE         = 8;   ! can't use multiple objects error (H)
+Constant MMULTI_PE        = 9;   ! [vestigial] can only use multiple objects error (I)
+Constant VAGUE_PE         = 10;  ! not sure what it refers to error (J)
+Constant EXCEPT_PE        = 11;  ! [vestigial] excepted something not included error (L)
+Constant VERB_PE          = 12;  ! not a verb I recognise error (N)
+Constant SCENERY_PE       = 13;  ! [vestigial] not something you need to refer to error (O)
+Constant ITGONE_PE        = 14;  ! can't see it at the moment error (K)
+Constant JUNKAFTER_PE     = 15;  ! [vestigial] didn't understand the way that finished error (P)
+Constant TOOFEW_PE        = 16;  ! not enough of those available error (Q)
+Constant NOTHING_PE       = 17;  ! nothing to do error [ parser nothing error internal rule responses ]
+Constant ASKSCOPE_PE      = 18;  ! referred to a determination of scope error
+Constant NOTINCONTEXT_PE  = 19;  ! noun did not make sense in that context error (R)
+Constant BLANKLINE_PE     = 20;  ! I beg your pardon error (X) [ Not formally a parser error, but used by I7 as if ]
+Constant ANIMAAGAIN_PE    = 21;  ! can't again the addressee error (S)
+Constant COMMABEGIN_PE    = 22;  ! comma can't begin error (T)  
+Constant MISSINGPERSON_PE = 23;  ! can't see whom to talk to error (U)
+Constant ANIMALISTEN_PE   = 24;  ! can't talk to inanimate things error (V)
+Constant TOTALK_PE        = 25;  ! didn't understand addressee's last name error (W)
 
 @h Grammar Line Variables.
 This is the I6 library parser in mostly untouched form: reformatted for template
@@ -1481,20 +1484,20 @@ Print best possible error message.
     }
     if (etype == NUMBER_PE) {   PARSER_ERROR_INTERNAL_RM('D'); new_line; }
     if (etype == CANTSEE_PE) {  PARSER_ERROR_INTERNAL_RM('E'); new_line; oops_from=saved_oops; }
-    if (etype == TOOLIT_PE) {   PARSER_ERROR_INTERNAL_RM('F'); new_line; }
-    if (etype == NOTHELD_PE) {  PARSER_ERROR_INTERNAL_RM('G'); new_line; oops_from=saved_oops; }
+    ! if (etype == TOOLIT_PE) {   PARSER_ERROR_INTERNAL_RM('F'); new_line; } ! vestigial
+    ! if (etype == NOTHELD_PE) {  PARSER_ERROR_INTERNAL_RM('G'); new_line; oops_from=saved_oops; } ! vestigial
     if (etype == MULTI_PE) {    PARSER_ERROR_INTERNAL_RM('H'); new_line; }
-    if (etype == MMULTI_PE) {   PARSER_ERROR_INTERNAL_RM('I'); new_line; }
+    ! if (etype == MMULTI_PE) {   PARSER_ERROR_INTERNAL_RM('I'); new_line; } ! vestigial
     if (etype == VAGUE_PE) {    PARSER_ERROR_INTERNAL_RM('J'); new_line; }
     if (etype == ITGONE_PE) {
         if (pronoun_obj == NULL) { PARSER_ERROR_INTERNAL_RM('J'); new_line; }
         else { PARSER_ERROR_INTERNAL_RM('K', noun); new_line; }
     }
-    if (etype == EXCEPT_PE) {   PARSER_ERROR_INTERNAL_RM('L'); new_line; }
+    ! if (etype == EXCEPT_PE) {   PARSER_ERROR_INTERNAL_RM('L'); new_line; } ! vestigial
     if (etype == ANIMA_PE) {    PARSER_ERROR_INTERNAL_RM('M'); new_line; }
     if (etype == VERB_PE) {     PARSER_ERROR_INTERNAL_RM('N'); new_line; }
-    if (etype == SCENERY_PE) {  PARSER_ERROR_INTERNAL_RM('O'); new_line; }
-    if (etype == JUNKAFTER_PE) {  PARSER_ERROR_INTERNAL_RM('P'); new_line; }
+    ! if (etype == SCENERY_PE) {  PARSER_ERROR_INTERNAL_RM('O'); new_line; } ! vestigial
+    ! if (etype == JUNKAFTER_PE) {  PARSER_ERROR_INTERNAL_RM('P'); new_line; } ! vestigial
     if (etype == TOOFEW_PE) {  PARSER_ERROR_INTERNAL_RM('Q', multi_had); new_line; }
     if (etype == NOTHING_PE) {
     	if (parser_results-->ACTION_PRES == ##Remove &&

--- a/inform7/Internal/Extensions/Graham Nelson/Standard Rules.i7xd/Source/Sections/Variables and Rulebooks.w
+++ b/inform7/Internal/Extensions/Graham Nelson/Standard Rules.i7xd/Source/Sections/Variables and Rulebooks.w
@@ -844,10 +844,10 @@ This is the announce items from multiple object lists rule:
 		say "[current item from the multiple object list]: [run paragraph on]" (A).
 
 This is the before stage rule:
-	abide by dialogue before action choices; 
+	abide by dialogue before action choices;
 	abide by the before rules.
 This is the instead stage rule:
-	abide by dialogue instead action choices; 
+	abide by dialogue instead action choices;
 	abide by the instead rules.
 
 @ The final rule in the rulebook always succeeds: this ensures that
@@ -1115,37 +1115,41 @@ When a scene (called the event) begins (this is the scene description text rule)
 
 @h Command parser errors.
 This abstracts a set of return codes from the I6 parser, which are written
-there as constants with the notation |*_ETYPE|.
+there as constants with the notation |*_ETYPE|.  (The constant definitions
+in Parser.i6t are commented with the corresponding command parser errors.)
+
+Corresponding Parser Error Internal Rule responses are given in comments.
+Some, labelled "vestigial" below are no longer in use.
 
 =
 Section 8 - Command parser errors
 
 A command parser error is a kind of value. The command parser errors are
-	didn't understand error,
-	only understood as far as error,
-	didn't understand that number error,
-	can only do that to something animate error,
-	can't see any such thing error,
-	said too little error,
-	aren't holding that error,
-	can't use multiple objects error,
-	can only use multiple objects error,
-	not sure what it refers to error,
-	excepted something not included error,
-	not a verb I recognise error,
-	not something you need to refer to error,
-	can't see it at the moment error,
-	didn't understand the way that finished error,
-	not enough of those available error,
-	nothing to do error,
-	referred to a determination of scope error,
-	noun did not make sense in that context error,
-	I beg your pardon error,
-	can't again the addressee error,
-	comma can't begin error,
-	can't see whom to talk to error,
-	can't talk to inanimate things error, and
-	didn't understand addressee's last name error.
+	didn't understand error, [ A ]
+	only understood as far as error, [ B, C ]
+	didn't understand that number error, [ D ]
+	can only do that to something animate error, [ M ]
+	can't see any such thing error, [ E ]
+	said too little error, [ F, vestigial ]
+	aren't holding that error, [ G, vestigial ]
+	can't use multiple objects error, [ H ]
+	can only use multiple objects error, [ I, vestigial ]
+	not sure what it refers to error, [ J ]
+	excepted something not included error, [ L, vestigial ]
+	not a verb I recognise error, [ N ]
+	not something you need to refer to error, [ O, vestigial ]
+	can't see it at the moment error, [ K ]
+	didn't understand the way that finished error, [ P, vestigial ]
+	not enough of those available error, [ Q ]
+	nothing to do error, [ see parser nothing error internal rule responses ]
+	referred to a determination of scope error, [ no corresponding response ]
+	noun did not make sense in that context error, [ R ]
+	I beg your pardon error, [ X ]
+	can't again the addressee error, [ S ]
+	comma can't begin error, [ T ]
+	can't see whom to talk to error, [ U ]
+	can't talk to inanimate things error, [ V ]
+	didn't understand addressee's last name error. [ W ]
 
 The latest parser error is a command parser error that varies.
 The latest parser error variable is defined by Inter as "etype".
@@ -1204,31 +1208,54 @@ The action processing internal rule is defined by Inter as
 
 The parser error internal rule is defined by Inter as
 	"PARSER_ERROR_INTERNAL_R" with
+	[ didn't understand error ]
 	"I didn't understand that sentence." (A),
-	"I only understood you as far as wanting to " (B),
-	"I only understood you as far as wanting to (go) " (C),
+	[ only understood as far as error ]
+		"I only understood you as far as wanting to " (B),
+		"I only understood you as far as wanting to (go) " (C),
+	[ didn't understand that number error ]
 	"I didn't understand that number." (D),
+	[ can't see any such thing error ]
 	"[We] [can't] see any such thing." (E),
+	[ said too little error (vestigial) ]
 	"You seem to have said too little!" (F),
+	[ aren't holding that error (vestigial) ]
 	"[We] [aren't] holding that!" (G),
+	[ can't use multiple objects error ]
 	"You can't use multiple objects with that verb." (H),
+	[ can only use multiple objects error (vestigial) ]
 	"You can only use multiple objects once on a line." (I),
+	[ not sure what it refers to error ]
 	"I'm not sure what ['][pronoun i6 dictionary word]['] refers to." (J),
+	[ can't see it at the moment error ]
 	"[We] [can't] see ['][pronoun i6 dictionary word]['] ([the noun]) at the moment." (K),
+	[ excepted something not included error (vestigial) ]
 	"You excepted something not included anyway!" (L),
+	[ can only do that to something animate error ]
 	"You can only do that to something animate." (M),
+	[ not a verb I recognise error ]
 	"That's not a verb I [if American dialect option is
 		active]recognize[otherwise]recognise[end if]." (N),
+	[ not something you need to refer to error (vestigial) ]
 	"That's not something you need to refer to in the course of this game." (O),
+	[ didn't understand the way that finished error (vestigial) ]
 	"I didn't understand the way that finished." (P),
+	[ not enough of those available error ]
 	"[if number understood is 0]None[otherwise]Only [number understood in words][end if]
 		of those [regarding the number understood][are] available." (Q),
+	[ noun did not make sense in that context error ]
 	"That noun did not make sense in this context." (R),
+	[ can't again the addressee error ]
 	"To repeat a command like 'frog, jump', just say 'again', not 'frog, again'." (S),
+	[ comma can't begin error ]
 	"You can't begin with a comma." (T),
+	[ can't see whom to talk to error ]
 	"You seem to want to talk to someone, but I can't see whom." (U),
+	[ can't talk to inanimate things error ]
 	"You can't talk to [the noun]." (V),
+	[ didn't understand addressee's last name error ]
 	"To talk to someone, try 'someone, hello' or some such." (W),
+	[ I beg your pardon error ]
 	"I beg your pardon?" (X).
 
 The parser nothing error internal rule is defined by Inter as


### PR DESCRIPTION
I just created improvement request [I7-2613](https://inform7.atlassian.net/browse/I7-2613) for this PR to refer to.

This adds comments to Parser.i6t identifying the command parser error / parser error internal rule responses to which the `*_PE` constants correspond, e.g.,

```
Constant STUCK_PE         = 1;   ! didn't understand error (A)
Constant UPTO_PE          = 2;   ! only understood as far as error (B) / (C)
Constant NUMBER_PE        = 3;   ! didn't understand that number error (D)
Constant ANIMA_PE         = 4;   ! can only do that to something animate error (M)
Constant CANTSEE_PE       = 5;   ! can't see any such thing error (E)
Constant TOOLIT_PE        = 6;   ! [vestigial] said too little error (F)
```

and, in the Standard Rules, cross-references between command parser errors and parser error internal rule responses:

```
A command parser error is a kind of value. The command parser errors are
        didn't understand error, [ A ]
        only understood as far as error, [ B, C ]
        didn't understand that number error, [ D ]
        can only do that to something animate error, [ M ]
        can't see any such thing error, [ E ]
        said too little error, [ F, vestigial ]
```

```
The parser error internal rule is defined by Inter as
        "PARSER_ERROR_INTERNAL_R" with
        [ didn't understand error ]
        "I didn't understand that sentence." (A),
        [ only understood as far as error ]
                "I only understood you as far as wanting to " (B),
                "I only understood you as far as wanting to (go) " (C),
        [ didn't understand that number error ]
        "I didn't understand that number." (D),
        [ can't see any such thing error ]
        "[We] [can't] see any such thing." (E),
        [ said too little error (vestigial) ]
        "You seem to have said too little!" (F),
```

As shown, it labels the errors / messages that are now vestigial; it further comments out testing for these vestigial errors in Parser.i6t, e.g.,
```
    ! if (etype == EXCEPT_PE) {   PARSER_ERROR_INTERNAL_RM('L'); new_line; } ! vestigial
    if (etype == ANIMA_PE) {    PARSER_ERROR_INTERNAL_RM('M'); new_line; }
    if (etype == VERB_PE) {     PARSER_ERROR_INTERNAL_RM('N'); new_line; }
    ! if (etype == SCENERY_PE) {  PARSER_ERROR_INTERNAL_RM('O'); new_line; } ! vestigial
    ! if (etype == JUNKAFTER_PE) {  PARSER_ERROR_INTERNAL_RM('P'); new_line; } ! vestigial
```

These are the only changes in the PR outside of code comments.

Arguably, it'd be an improvement to elide the vestiges altogether. That would result in different numeric values for most of the `*_PE` constants and skipping letters in the rule responses (or re-lettering them, I would guess that skipping would be preferable). I erred on the side of conservatism here and just labeled them.