### PR TITLE
fix to block kissing rule response

### DIFF
--- a/inform7/Internal/Extensions/Graham Nelson/Standard Rules.i7xd/Source/Sections/Actions.w
+++ b/inform7/Internal/Extensions/Graham Nelson/Standard Rules.i7xd/Source/Sections/Actions.w
@@ -2084,7 +2084,7 @@ Check an actor kissing (this is the kissing yourself rule):
 
 Check an actor kissing (this is the block kissing rule):
 	if the actor is the player:
-		say "[The noun] [might not] like that." (A);
+		say "[The noun] [might not like] that." (A);
 	stop the action.
 
 @h Answering it that.


### PR DESCRIPTION
Fix for [I7-2620](https://inform7.atlassian.net/browse/I7-2620); changes "[The noun] [might not] like that." to "[The noun] [might not like] that."