### PR TITLE
Glk unicode file functions for external file reference in Architecture32Kit, I7-2391

### DIFF
--- a/inform7/Internal/Extensions/Graham Nelson/Basic Inform.i7xd/Materials/Inter/Architecture32Kit/Sections/File Input Output.i6t
+++ b/inform7/Internal/Extensions/Graham Nelson/Basic Inform.i7xd/Materials/Inter/Architecture32Kit/Sections/File Input Output.i6t
@@ -13,6 +13,7 @@ the Inform user interface, they are either (for preference) stored in a
 alongside the Inform project file.
 
 =
+
 [ FileIO_Exists extf  fref struc rv usage;
 	if ((extf < 1) || (extf > NO_EXTERNAL_FILES)) rfalse;
 	struc = TableOfExternalFiles-->extf;
@@ -85,10 +86,11 @@ asterisk or hyphen into the initial character as needed.
 		glk_fileref_destroy(fref);
 		return FileIO_Error(extf, "only closed files can be marked");
 	}
-	str = glk_stream_open_file(fref, filemode_ReadWrite, 0);
+	if (usage = fileusage_BinaryMode) str = glk_stream_open_file(fref, filemode_ReadWrite, 0);
+	else str = glk_stream_open_file(fref, filemode_ReadWrite, 0);
 	glk_stream_set_position(str, 0, 0); ! seek start
 	if (readiness) ch = '*'; else ch = '-';
-	glk_put_char_stream(str, ch); ! mark as complete
+	glk_put_char_stream_uni(str, ch); ! mark as complete
 	glk_stream_close(str, 0);
 	glk_fileref_destroy(fref);
 ];
@@ -122,7 +124,8 @@ asterisk or hyphen into the initial character as needed.
 			return FileIO_Error(extf, "tried to open a file which does not exist");
 		}
 	}
-	str = glk_stream_open_file(fref, mode, 0);
+	if (usage == fileusage_TextMode) str = glk_stream_open_file_uni(fref, mode, 0);
+	else str = glk_stream_open_file(fref, mode, 0);
 	glk_fileref_destroy(fref);
 	if (str == 0) return FileIO_Error(extf, "tried to open a file but failed");
 	struc-->AUXF_STREAM = str;
@@ -214,7 +217,8 @@ Glk errors.
 	if ((extf < 1) || (extf > NO_EXTERNAL_FILES)) return -1;
 	struc = TableOfExternalFiles-->extf;
 	if (struc-->AUXF_STATUS ~= AUXF_STATUS_IS_OPEN_FOR_READ) return -1;
-	return glk_get_char_stream(struc-->AUXF_STREAM);
+	if (struc-->AUXF_BINARY) return glk_get_char_stream(struc-->AUXF_STREAM);
+	return glk_get_char_stream_uni(struc-->AUXF_STREAM);
 ];
 
 @h Put Character.
@@ -229,7 +233,8 @@ Glk errors.
 		AUXF_STATUS_IS_OPEN_FOR_APPEND)
 		return FileIO_Error(extf,
 			"tried to write to a file which is not open for writing");
-	return glk_put_char_stream(struc-->AUXF_STREAM, char);
+	if (struc-->AUXF_BINARY) return glk_put_char_stream(struc-->AUXF_STREAM, char);
+	return glk_put_char_stream_uni(struc-->AUXF_STREAM, char);
 ];
 
 @h Print Line.
@@ -246,7 +251,8 @@ single `0d`.) Each character is printed, and at the end we print a newline.
 		ch = FileIO_GetC(extf);
 		if (ch == -1) rfalse;
 		if (ch == 10 or 13) { print "^"; rtrue; }
-		print (char) ch;
+		if (struc-->AUXF_BINARY) print (char) ch;
+		else @streamunichar ch;
 	}
 ];
 
@@ -284,12 +290,14 @@ end (if true).
 	oldstream = glk_stream_get_current();
 	str = FileIO_Open(extf, true, append_flag);
 	if (str == 0) rfalse;
-	@push say__p; @push say__pc;
+	@push say__p;
+	@push say__pc;
 	ClearParagraphing(19);
 	TEXT_TY_Say(text);
 	FileIO_Close(extf);
 	if (oldstream) glk_stream_set_current(oldstream);
-	@pull say__pc; @pull say__p;
+	@pull say__pc;
+	@pull say__p;
 	rfalse;
 ];
 

--- a/inform7/Internal/Extensions/Graham Nelson/Basic Inform.i7xd/Materials/Inter/Architecture32Kit/Sections/File Input Output.i6t
+++ b/inform7/Internal/Extensions/Graham Nelson/Basic Inform.i7xd/Materials/Inter/Architecture32Kit/Sections/File Input Output.i6t
@@ -13,7 +13,7 @@ the Inform user interface, they are either (for preference) stored in a
 alongside the Inform project file.
 
 =
-
+! works for text or binary mode files
 [ FileIO_Exists extf  fref struc rv usage;
 	if ((extf < 1) || (extf > NO_EXTERNAL_FILES)) rfalse;
 	struc = TableOfExternalFiles-->extf;
@@ -49,33 +49,35 @@ in having this marker asterisk.
 asterisk or hyphen into the initial character as needed.
 
 =
+! issues RTP for binary mode
 [ FileIO_Ready extf  struc fref usage str ch;
 	if ((extf < 1) || (extf > NO_EXTERNAL_FILES)) rfalse;
 	struc = TableOfExternalFiles-->extf;
 	if ((struc == 0) || (struc-->AUXF_MAGIC ~= AUXF_MAGIC_VALUE)) rfalse;
-	if (struc-->AUXF_BINARY) usage = fileusage_BinaryMode;
-	else usage = fileusage_TextMode;
+	if (struc-->AUXF_BINARY) return FileIO_Error(extf, "binary file ineligible to be tested for readiness");
+	usage = fileusage_TextMode;
 	fref = glk_fileref_create_by_name(fileusage_Data + usage,
 		Glulx_ChangeAnyToCString(struc-->AUXF_FILENAME), 0);
 	if (glk_fileref_does_file_exist(fref) == false) {
 		glk_fileref_destroy(fref);
 		rfalse;
 	}
-	str = glk_stream_open_file(fref, filemode_Read, 0);
-	ch = glk_get_char_stream(str);
+	str = glk_stream_open_file_uni(fref, filemode_Read, 0);
+	ch = glk_get_char_stream_uni(str);
 	glk_stream_close(str, 0);
 	glk_fileref_destroy(fref);
 	if (ch ~= '*') rfalse;
 	rtrue;
 ];
 
+! issues RTP for binary mode
 [ FileIO_MarkReady extf readiness  struc fref str ch usage;
 	if ((extf < 1) || (extf > NO_EXTERNAL_FILES))
 		return FileIO_Error(extf, "tried to open a non-file");
 	struc = TableOfExternalFiles-->extf;
 	if ((struc == 0) || (struc-->AUXF_MAGIC ~= AUXF_MAGIC_VALUE)) rfalse;
-	if (struc-->AUXF_BINARY) usage = fileusage_BinaryMode;
-	else usage = fileusage_TextMode;
+	if (struc-->AUXF_BINARY) return FileIO_Error(extf, "binary file ineligible to be marked ready for reading");
+	usage = fileusage_TextMode;
 	fref = glk_fileref_create_by_name(fileusage_Data + usage,
 		Glulx_ChangeAnyToCString(struc-->AUXF_FILENAME), 0);
 	if (glk_fileref_does_file_exist(fref) == false) {
@@ -86,11 +88,12 @@ asterisk or hyphen into the initial character as needed.
 		glk_fileref_destroy(fref);
 		return FileIO_Error(extf, "only closed files can be marked");
 	}
-	if (usage = fileusage_BinaryMode) str = glk_stream_open_file(fref, filemode_ReadWrite, 0);
-	else str = glk_stream_open_file(fref, filemode_ReadWrite, 0);
+	str = glk_stream_open_file_uni(fref, filemode_ReadWrite, 0);
 	glk_stream_set_position(str, 0, 0); ! seek start
-	if (readiness) ch = '*'; else ch = '-';
-	glk_put_char_stream_uni(str, ch); ! mark as complete
+	if (readiness) ch = '*';
+	else ch = '-';
+	! mark as complete
+	glk_put_char_stream_uni(str, ch);
 	glk_stream_close(str, 0);
 	glk_fileref_destroy(fref);
 ];
@@ -98,6 +101,7 @@ asterisk or hyphen into the initial character as needed.
 @h Open File.
 
 =
+! text mode assumed
 [ FileIO_Open extf write_flag append_flag
 	struc fref str mode ix ch not_this_ifid owner force_header usage;
 	if ((extf < 1) || (extf > NO_EXTERNAL_FILES))
@@ -124,8 +128,7 @@ asterisk or hyphen into the initial character as needed.
 			return FileIO_Error(extf, "tried to open a file which does not exist");
 		}
 	}
-	if (usage == fileusage_TextMode) str = glk_stream_open_file_uni(fref, mode, 0);
-	else str = glk_stream_open_file(fref, mode, 0);
+	str = glk_stream_open_file_uni(fref, mode, 0);
 	glk_fileref_destroy(fref);
 	if (str == 0) return FileIO_Error(extf, "tried to open a file but failed");
 	struc-->AUXF_STREAM = str;
@@ -191,6 +194,7 @@ Note that a call to the following, in write mode, must be followed by a
 Glk errors.
 
 =
+! text mode assumed
 [ FileIO_Close extf  struc;
 	if ((extf < 1) || (extf > NO_EXTERNAL_FILES))
 		return FileIO_Error(extf, "tried to open a non-file");
@@ -204,7 +208,7 @@ Glk errors.
 		AUXF_STATUS_IS_OPEN_FOR_WRITE or
 		AUXF_STATUS_IS_OPEN_FOR_APPEND) {
 		glk_stream_set_position(struc-->AUXF_STREAM, 0, 0); ! seek start
-		glk_put_char_stream(struc-->AUXF_STREAM, '*'); ! mark as complete
+		glk_put_char_stream_uni(struc-->AUXF_STREAM, '*'); ! mark as complete
 	}
 	glk_stream_close(struc-->AUXF_STREAM, 0);
 	struc-->AUXF_STATUS = AUXF_STATUS_IS_CLOSED;
@@ -213,17 +217,18 @@ Glk errors.
 @h Get Character.
 
 =
+! text mode assumed
 [ FileIO_GetC extf  struc;
 	if ((extf < 1) || (extf > NO_EXTERNAL_FILES)) return -1;
 	struc = TableOfExternalFiles-->extf;
 	if (struc-->AUXF_STATUS ~= AUXF_STATUS_IS_OPEN_FOR_READ) return -1;
-	if (struc-->AUXF_BINARY) return glk_get_char_stream(struc-->AUXF_STREAM);
 	return glk_get_char_stream_uni(struc-->AUXF_STREAM);
 ];
 
 @h Put Character.
 
 =
+! text mode assumed
 [ FileIO_PutC extf char  struc;
 	if ((extf < 1) || (extf > NO_EXTERNAL_FILES))
 		return FileIO_Error(extf, "tried to write to a non-file");
@@ -233,7 +238,6 @@ Glk errors.
 		AUXF_STATUS_IS_OPEN_FOR_APPEND)
 		return FileIO_Error(extf,
 			"tried to write to a file which is not open for writing");
-	if (struc-->AUXF_BINARY) return glk_put_char_stream(struc-->AUXF_STREAM, char);
 	return glk_put_char_stream_uni(struc-->AUXF_STREAM, char);
 ];
 
@@ -243,6 +247,7 @@ character. (We allow for that to be encoded as either a single `0a` or a
 single `0d`.) Each character is printed, and at the end we print a newline.
 
 =
+! text mode assumed
 [ FileIO_PrintLine extf ch  struc;
 	if ((extf < 1) || (extf > NO_EXTERNAL_FILES))
 		return FileIO_Error(extf, "tried to write to a non-file");
@@ -251,8 +256,7 @@ single `0d`.) Each character is printed, and at the end we print a newline.
 		ch = FileIO_GetC(extf);
 		if (ch == -1) rfalse;
 		if (ch == 10 or 13) { print "^"; rtrue; }
-		if (struc-->AUXF_BINARY) print (char) ch;
-		else @streamunichar ch;
+		print (char) ch;
 	}
 ];
 
@@ -263,6 +267,7 @@ output stream. (This might well be another file, just as with `cat`, in
 which case we have a copy utility.)
 
 =
+! issues RTP for binary mode
 [ FileIO_PrintContents extf tab  struc;
 	if ((extf < 1) || (extf > NO_EXTERNAL_FILES))
 		return FileIO_Error(extf, "tried to access a non-file");
@@ -281,6 +286,7 @@ either as the whole file (if `append_flag` is false) or adding only to the
 end (if true).
 
 =
+! issues RTP for binary mode
 [ FileIO_PutContents extf text append_flag  struc str ch oldstream;
 	if ((extf < 1) || (extf > NO_EXTERNAL_FILES))
 		return FileIO_Error(extf, "tried to access a non-file");


### PR DESCRIPTION
Addressing [I7-2391](https://inform7.atlassian.net/browse/I7-2391), using Glk unicode file functions for external file reference in Architecture32Kit.

BIP-FilesOfTables-C and BIP-Files-C fail with:
> Unimplemented Glk selector: 312.
> *** Fatal error: halted ***

'cause MiniGlk doesn't have the Glk unicode calls. 