### PR TITLE
Finish the hyperlinks framework

### DIFF
--- a/inform7/Internal/Extensions/Graham Nelson/Basic Inform.i7xd/Materials/Inter/Architecture32Kit/RTPs/HyperlinkEphemeral.md
+++ b/inform7/Internal/Extensions/Graham Nelson/Basic Inform.i7xd/Materials/Inter/Architecture32Kit/RTPs/HyperlinkEphemeral.md
@@ -1,0 +1,3 @@
+# Tagged hyperlinks cannot contain ephemeral values
+
+You cannot create a tagged hyperlink from an ephemeral value. You might be trying to make a hyperlink with a temporary local variable, which cannot be done. Or the I6 phrase might need to pass the value by reference: `{-by-reference:V}`.

--- a/inform7/Internal/Extensions/Graham Nelson/Basic Inform.i7xd/Materials/Inter/Architecture32Kit/RTPs/HyperlinkInvalid.md
+++ b/inform7/Internal/Extensions/Graham Nelson/Basic Inform.i7xd/Materials/Inter/Architecture32Kit/RTPs/HyperlinkInvalid.md
@@ -1,0 +1,3 @@
+# Cannot process an invalid tagged hyperlink
+
+You cannot process an invalid tagged hyperlink in order to extract its hyperlink tag or value.

--- a/inform7/Internal/Extensions/Graham Nelson/Basic Inform.i7xd/Materials/Inter/Architecture32Kit/RTPs/HyperlinkRealNumber.md
+++ b/inform7/Internal/Extensions/Graham Nelson/Basic Inform.i7xd/Materials/Inter/Architecture32Kit/RTPs/HyperlinkRealNumber.md
@@ -1,0 +1,3 @@
+# Tagged hyperlinks cannot contain real numbers
+
+While tagged hyperlinks can contain most kinds, real numbers are an exception.

--- a/inform7/Internal/Extensions/Graham Nelson/Basic Inform.i7xd/Materials/Inter/Architecture32Kit/Sections/Glk.i6t
+++ b/inform7/Internal/Extensions/Graham Nelson/Basic Inform.i7xd/Materials/Inter/Architecture32Kit/Sections/Glk.i6t
@@ -343,7 +343,7 @@ Constant GLK_EVENT_TEXT_SF = 6;
 					print ev-->GLK_EVENT_VALUE1_SF, ", ", ev-->GLK_EVENT_VALUE2_SF;
 				}
 			evtype_Hyperlink:
-				print ev-->GLK_EVENT_VALUE1_SF;
+				SayKindValuePair(HYPERLINK_TAG_TY, ((ev-->GLK_EVENT_VALUE1_SF) & hyperlink_tag_mask));
 		}
 		print ") in ", (the) win_obj;
 	}
@@ -765,20 +765,23 @@ up into its parts again.
 
 =
 [ TAGGED_HYPERLINK_TY_New tag val kind make_link;
-	#Ifdef DEBUG;
-		if (val >= blockv_stack && val < (blockv_stack + BLOCKV_STACK_SIZE * WORDSIZE)) {
-			if (kind) {
-				if (KindConformsTo_POINTER_VALUE_TY(kind)) {
-					! Break up the message so that Inform doesn't think it's an Inter invocation
-					print "Error: cannot make hyperlink from ephemeral value; try creating with {", "-by-reference:V}^";
-					return;
-				}
-			}
-			else {
-				print "Warning: hyperlink value might be ephemeral; try creating with explicit kind^";
+	if (kind == REAL_NUMBER_TY) {
+		IssueRTP("HyperlinkRealNumber", "TAGGED_HYPERLINK_TY_New: Tagged hyperlinks cannot contain real numbers.", Architecture32KitRTPs);
+		return 0;
+	}
+	if (val >= blockv_stack && val < (blockv_stack + BLOCKV_STACK_SIZE * WORDSIZE)) {
+		if (kind) {
+			if (KindConformsTo_POINTER_VALUE_TY(kind)) {
+				IssueRTP("HyperlinkEphemeral", "TAGGED_HYPERLINK_TY_New: Tagged hyperlinks cannot contain ephemeral values.", Architecture32KitRTPs);
+				return 0;
 			}
 		}
-	#Endif; ! DEBUG
+		else {
+			#Ifdef DEBUG;
+			print "Warning: hyperlink value might be ephemeral; try creating with explicit kind^";
+			#Endif; ! DEBUG
+		}
+	}
 	if (val > 0) {
 		@shiftl val hyperlink_tag_width val;
 	}
@@ -792,17 +795,33 @@ up into its parts again.
 	return val;
 ];
 
-[ TAGGED_HYPERLINK_TY_Say val;
+[ TAGGED_HYPERLINK_TY_Say val tag;
 	print "tagged hyperlink (";
-	SayKindValuePair(HYPERLINK_TAG_TY, (val & hyperlink_tag_mask));
+	tag = val & hyperlink_tag_mask;
+	if (tag == 0) {
+		print "invalid";
+	}
+	else {
+		SayKindValuePair(HYPERLINK_TAG_TY, tag);
+	}
 	print ")";
 ];
 
 [ TAGGED_HYPERLINK_TY_Tag val;
-	return (val & hyperlink_tag_mask);
+	val = val & hyperlink_tag_mask;
+	if (val == 0 || val > ICOUNT_HYPERLINK_TAG) {
+		IssueRTP("HyperlinkInvalid", "TAGGED_HYPERLINK_TY_Tag: Cannot process an invalid tagged hyperlink.", Architecture32KitRTPs);
+		return 0;
+	}
+	return val;
 ];
 
-[ TAGGED_HYPERLINK_TY_Value val;
+[ TAGGED_HYPERLINK_TY_Value val tag;
+	tag = val & hyperlink_tag_mask;
+	if (tag == 0 || tag > ICOUNT_HYPERLINK_TAG) {
+		IssueRTP("HyperlinkInvalid", "TAGGED_HYPERLINK_TY_Value: Cannot process an invalid tagged hyperlink.", Architecture32KitRTPs);
+		return 0;
+	}
 	val = val & hyperlink_payload_mask;
 	if (val < 0) {
 		val = val | hyperlink_tag_mask;

--- a/inform7/Internal/Extensions/Graham Nelson/Basic Inform.i7xd/Materials/Inter/Architecture32Kit/kinds/Glk.neptune
+++ b/inform7/Internal/Extensions/Graham Nelson/Basic Inform.i7xd/Materials/Inter/Architecture32Kit/kinds/Glk.neptune
@@ -109,7 +109,7 @@ new base TAGGED_HYPERLINK_TY {
 	singular: tagged hyperlink
 	plural: tagged hyperlinks
 
-	default-value: 1
+	default-value: 0
 	say-function: TAGGED_HYPERLINK_TY_Say
 
 	specification-text: A tagged hyperlink combines a hyperlink tag and a value.

--- a/inform7/Internal/Extensions/Graham Nelson/Basic Inform.i7xd/Source/Sections/Glulx and Glk.w
+++ b/inform7/Internal/Extensions/Graham Nelson/Basic Inform.i7xd/Source/Sections/Glulx and Glk.w
@@ -247,33 +247,54 @@ To decide what K is hyperlink value as a/an (name of kind of value K):
 
 @ And some built-in hyperlink tags:
 
-- A number hyperlink stores a number but doesn't do anything when clicked. It's
-  basically just here to give a tagged hyperlink a sensible default value.
-- A rule hyperlink runs a rule when clicked; that in turn allows you to run any
-  other code you like.
+- A command replacement hyperlink replaces the entire pending line input with
+  a specified text and then submits it, as if the player pressed enter.
+- A command appendment hyperlink suspends line input, adds its text to the
+  current line input, and then resumes line input.
 - A keypress hyperlink converts a hyperlink event into a character event, for
   the specified unicode character.
+- A rule hyperlink runs a rule when clicked; that in turn allows you to run any
+  other code you like.
 
 =
-Number hyperlink is a hyperlink tag.
+Command replacement is a hyperlink tag.
+The command replacement value is accessible to Inter as "hyperlink_replace".
 
-Rule hyperlink is a hyperlink tag.
-The rule hyperlink value is accessible to Inter as "rule_hyperlink".
+To say link command/-- replacement of/-- (T - text):
+	(- TAGGED_HYPERLINK_TY_New(hyperlink_replace, {-by-reference:T}, TEXT_TY, 1); -).
 
-To say link (R - rule):
-	(- TAGGED_HYPERLINK_TY_New(rule_hyperlink, {-by-reference:R}, RULE_TY, 1); -).
+Hyperlink handling rule for command replacement (this is the command replacement hyperlink rule):
+	suspend text input in the main window, without input echoing;
+	replace current event with a line event with (hyperlink value as a text);
 
-Hyperlink handling rule for a rule hyperlink (this is the rule hyperlink rule):
-	follow hyperlink value as a rule;
+Command appendment is a hyperlink tag.
+The command appendment value is accessible to Inter as "hyperlink_append".
+
+To say link append (T - text):
+	(- TAGGED_HYPERLINK_TY_New(hyperlink_append, {-by-reference:T}, TEXT_TY, 1); -).
+
+Hyperlink handling rule for command appendment (this is the command appendment hyperlink rule):
+	suspend text input in the main window, without input echoing;
+	set the current line input of the main window to "[current line input of the main window] [hyperlink value as a text]";
+	resume text input in the main window;
 
 Keypress hyperlink is a hyperlink tag.
-The keypress hyperlink value is accessible to Inter as "keypress_hyperlink".
+The keypress hyperlink value is accessible to Inter as "hyperlink_keypress".
 
 To say link (C - unicode character):
-	(- TAGGED_HYPERLINK_TY_New(keypress_hyperlink, {-by-reference:C}, UNICODE_CHARACTER_TY, 1); -).
+	(- TAGGED_HYPERLINK_TY_New(hyperlink_keypress, {-by-reference:C}, UNICODE_CHARACTER_TY, 1); -).
 
 Hyperlink handling rule for a keypress hyperlink (this is the keypress hyperlink rule):
 	replace current event with a character event with (hyperlink value as a unicode character);
+
+Rule hyperlink is a hyperlink tag.
+The rule hyperlink value is accessible to Inter as "hyperlink_rule".
+
+To say link (R - rule):
+	(- TAGGED_HYPERLINK_TY_New(hyperlink_rule, {-by-reference:R}, RULE_TY, 1); -).
+
+Hyperlink handling rule for a rule hyperlink (this is the rule hyperlink rule):
+	follow hyperlink value as a rule;
 
 @h Suspending input.
 These properties and phrases allow the author to suspend and resume input requests.


### PR DESCRIPTION
Add some safety checks.

Add two more built in hyperlink tags: command replacement and command appendment, for replacing the whole line input, or adding some text to it.

Changed the default of a tagged hyperlink to a be a null value (`0`), and removed the number tag as it's not useful.