### PR TITLE
giving PARSE_BUFFER_LEN constant a computed value, not static

### DIFF
--- a/inform7/Internal/Extensions/Graham Nelson/Basic Inform.i7xd/Materials/Inter/Architecture32Kit/Sections/Input Output.i6t
+++ b/inform7/Internal/Extensions/Graham Nelson/Basic Inform.i7xd/Materials/Inter/Architecture32Kit/Sections/Input Output.i6t
@@ -145,7 +145,7 @@ Global gg_backgroundchan = 0;
 
 Constant INPUT_BUFFER_LEN = 260;    ! No extra byte necessary
 Constant MAX_BUFFER_WORDS = 20;
-Constant PARSE_BUFFER_LEN = 61;
+Constant PARSE_BUFFER_LEN = (3 * MAX_BUFFER_WORDS) + 1;
 
 Array  buffer   --> INPUT_BUFFER_LEN;
 Array  buffer2  --> INPUT_BUFFER_LEN;


### PR DESCRIPTION
Make `PARSE_BUFFER_LEN` appropriately dependent on `MAX_BUFFER_WORDS`.

Perhaps `MAX_BUFFER_WORDS` and `INPUT_BUFFER_LEN` would better be kit configuration-values. And maybe `INPUT_BUFFER_LEN`'s default  in Architecture32Kit should go up in light of `DICT_WORD_SIZE`'s increase. 320, maybe?
(400 would constitute a similar proportion, but of course one would expect a much smaller increase in average word size.)